### PR TITLE
add travis ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: rust
+sudo: false
+os:
+- linux
+- osx
+rust:
+- stable
+- nightly
+- beta
+script:
+  cargo test


### PR DESCRIPTION
this will add CI support powered by https://travis-ci.com – you'll need to sign in with your github account to use their free service for open source projects. If you need any help, let me know.

Bonus: With this config, you get MacOS tests for free (we can deactivate them if they don't work).