### PR TITLE
Add support for FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ let mut my_shmem: SharedMem = match SharedMem::open(PathBuf::from("shared_mem.li
 
 ## Operating System Support
 
-| Feature| Description | Linux | Windows|  Mac<sup>[1]</sup>|
-|--------|-------------|:-----:|:------:|:----:|
-|SharedMem.create/open|Create/open a SharedMem|✔|✔|✔|
-|SharedMem.*_raw|Create/open a raw shared memory map|✔|✔|✔|
-|LockType::Mutex|Mutually exclusive lock|✔|✔</sup>|✔|
-|LockType::RwLock|Exlusive write/shared read|✔|X<sup>[2]</sup>|✔|
+| Feature| Description | Linux | Windows|  Mac<sup>[1]</sup>| FreeBSD |
+|--------|-------------|:-----:|:------:|:----:| :-----: |
+|SharedMem.create/open|Create/open a SharedMem|✔|✔|✔|✔|
+|SharedMem.*_raw|Create/open a raw shared memory map|✔|✔|✔|✔|
+|LockType::Mutex|Mutually exclusive lock|✔|✔</sup>|✔|✔|
+|LockType::RwLock|Exlusive write/shared read|✔|X<sup>[2]</sup>|✔|✔|
 
 <sup>[1] I do not own a Mac so cannot properly test this library other than building against OSX.</sup>
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,10 +39,7 @@ cfg_if! {
     if #[cfg(target_os="windows")] {
         mod win;
         use win as os_impl;
-    } else if #[cfg(target_os="linux")] {
-        mod nix;
-        use nix as os_impl;
-    } else if #[cfg(target_os="macos")] {
+    } else if #[cfg(any(target_os="freebsd", target_os="linux", target_os="macos"))] {
         mod nix;
         use nix as os_impl;
     } else {

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -251,7 +251,7 @@ pub fn open(mut new_file: SharedMem) -> Result<SharedMem> {
 pub fn create(mut new_file: SharedMem, lock_type: LockType) -> Result<SharedMem> {
     #[cfg(target_os="macos")]
     let max_path_len = 30;
-    #[cfg(target_os="linux")]
+    #[cfg(any(target_os="freebsd", target_os="linux"))]
     let max_path_len = 255;
     // real_path is either :
     // 1. Specified directly


### PR DESCRIPTION
With these changes the crate builds, tests pass and examples run on FreeBSD (11.1).

Also you might want to update the repo description, which currently reads:

> A wrapper around native shared memory for Linux and Windows 