### PR TITLE
Metadata does not depend on pointer size. 

### DIFF
--- a/src/conf.rs
+++ b/src/conf.rs
@@ -26,17 +26,20 @@ fn align_value(val: &mut usize, align: u8) -> u8 {
 }
 
 //Structs used in the shared memory metadata
+#[repr(C)]
 struct MetaDataHeader {
-    meta_size: usize,
-    user_size: usize,
-    num_locks: usize,
-    num_events: usize,
+    meta_size: u64,
+    user_size: u64,
+    num_locks: u64,
+    num_events: u64,
 }
+#[repr(C)]
 struct LockHeader {
     uid: u8,
-    offset: usize,
-    length: usize,
+    offset: u64,
+    length: u64,
 }
+#[repr(C)]
 struct EventHeader {
     uid: u8,
 }
@@ -242,10 +245,10 @@ impl<'a> SharedMemConf<'a> {
         //Initialize meta data
         let meta_header: &mut MetaDataHeader = unsafe{&mut (*(cur_ptr as *mut MetaDataHeader))};
         //Set the header for our shared memory
-        meta_header.meta_size = meta_size;
-        meta_header.user_size = self.size;
-        meta_header.num_locks = self.lock_data.len();
-        meta_header.num_events = self.event_data.len();
+        meta_header.meta_size = meta_size as u64;
+        meta_header.user_size = self.size as u64;
+        meta_header.num_locks = self.lock_data.len() as u64;
+        meta_header.num_events = self.event_data.len() as u64;
         cur_ptr += size_of::<MetaDataHeader>();
 
         //Initialize locks
@@ -253,8 +256,8 @@ impl<'a> SharedMemConf<'a> {
             //Set lock header
             let lock_header: &mut LockHeader = unsafe{&mut (*(cur_ptr as *mut LockHeader))};
             lock_header.uid = lock.uid;
-            lock_header.offset = lock.offset;
-            lock_header.length = lock.length;
+            lock_header.offset = lock.offset as u64;
+            lock_header.length = lock.length as u64;
             cur_ptr += size_of::<LockHeader>();
             align_value(&mut cur_ptr, ADDR_ALIGN);
 
@@ -340,10 +343,10 @@ impl<'a> SharedMemConf<'a> {
         let meta_header: &mut MetaDataHeader = unsafe{&mut (*(cur_ptr as *mut MetaDataHeader))};
         cur_ptr += size_of::<MetaDataHeader>();
 
-        self.size = meta_header.user_size;
+        self.size = meta_header.user_size as usize;
 
         //Basic size check on (metadata size + userdata size)
-        if os_map.map_size < (meta_header.meta_size + meta_header.user_size) {
+        if (os_map.map_size as u64) < (meta_header.meta_size + meta_header.user_size) {
             return Err(From::from(
                 format!("Shared memory header contains an invalid mapping size : (map_size: {}, meta_size: {}, user_size: {})",
                     os_map.map_size,
@@ -353,7 +356,7 @@ impl<'a> SharedMemConf<'a> {
         }
 
         //Add the metadata size to our base pointer to get user addr
-        let user_ptr = os_map.map_ptr as usize + meta_header.meta_size;
+        let user_ptr = os_map.map_ptr as usize + meta_header.meta_size as usize;
 
         //Open&initialize all locks
         for i in 0..meta_header.num_locks {
@@ -378,12 +381,12 @@ impl<'a> SharedMemConf<'a> {
             println!("\tFound new lock \"{:?}\" : offset {} length {}", lock_type, lock_header.offset, lock_header.length);
 
             //Add new lock to our config
-            self.add_lock_impl(lock_type, lock_header.offset, lock_header.length)?;
+            self.add_lock_impl(lock_type, lock_header.offset as usize, lock_header.length as usize)?;
 
             let new_lock: &mut GenericLock = self.lock_data.last_mut().unwrap();
 
             new_lock.lock_ptr = cur_ptr as *mut c_void;
-            new_lock.data_ptr = (user_ptr + lock_header.offset) as *mut c_void;
+            new_lock.data_ptr = (user_ptr + lock_header.offset as usize) as *mut c_void;
 
             cur_ptr += new_lock.interface.size_of();
             //Make sure memory is big enough to hold lock data
@@ -450,7 +453,7 @@ impl<'a> SharedMemConf<'a> {
 
         if cur_ptr != user_ptr {
             return Err(From::from(format!("Shared memory metadata does not end right before user data ! 0x{:x} != 0x{:x}", cur_ptr, user_ptr)));
-        } else if self.meta_size != meta_header.meta_size {
+        } else if self.meta_size as u64 != meta_header.meta_size {
             return Err(From::from(format!("Shared memory metadata does not match what was advertised ! {} != {}", self.meta_size, meta_header.meta_size)));
         }
 


### PR DESCRIPTION
This fix allows IPC between 32- and 64-bit applications.
Use case: 32-bit application creates shared memory, 64-bit application opens it.
```cargo run --example custom_create --target=i686-pc-windows-msvc```
```cargo run --example custom_open --target=x86_64-pc-windows-msvc```
Before this commit the second application terminates with error:
```Error : Shared memory header contains an invalid mapping size : (map_size: 8192, meta_size: 8589934592, user_size: 17592186044448)```