### PR TITLE
+ file lock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ log = "0.4"
 theban_interval_tree = "0.7"
 memrange = "0.1"
 rand = "0.4"
+fs2 = { version = "0.4.3", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.10"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@ extern crate cfg_if;
 extern crate enum_primitive;
 #[macro_use]
 extern crate log;
+#[cfg(feature="fs2")]
+extern crate fs2;
 
 use std::ffi::OsStr;
 use std::path::{PathBuf, Path};


### PR DESCRIPTION
# Сhanges

This fork has a feature `rs2` that allows you to safely create shared memory through file locks.
Example of common to all processes code:
```rust
SharedMem::open_linked(file_name)
    .or_else(|_|SharedMem::create_linked(file_name, LockType::RwLock, 4096))
    .or_else(|_|SharedMem::open_linked(file_name))
    .ok()
```