### PR TITLE
Potentially fix drop conditional for Windows

### DIFF
--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -67,7 +67,7 @@ impl Drop for MapData {
     ///Takes care of properly closing the SharedMem (munmap(), shmem_unlink(), close())
     fn drop(&mut self) {
         //Unmap memory from our process
-        if self.map_ptr as *mut _ == NULL {
+        if self.map_ptr as *mut _ != NULL {
             unsafe { UnmapViewOfFile(self.map_ptr as *mut _); }
         }
 


### PR DESCRIPTION
Hi!

I was scrolling through the source and this conditional looked off to me. Is it meant to be `!=`?

I'm pretty new to Rust, so forgive me if I misread the code 🙂 