### PR TITLE
revoke ownership on fork

### DIFF
--- a/src/nix/mod.rs
+++ b/src/nix/mod.rs
@@ -104,6 +104,12 @@ pub struct MapData {
     pub map_ptr: *mut c_void,
 }
 
+impl MapData {
+    pub fn is_owner(&self) -> bool {
+        self.owner && self.pid == unsafe { libc::getpid() }
+    }
+}
+
 ///shared memory teardown for linux
 impl Drop for MapData {
     ///Takes care of properly closing the SharedMem (munmap(), shmem_unlink(), close())
@@ -123,7 +129,7 @@ impl Drop for MapData {
         //Unlink shmem
         if self.map_fd != 0 {
             //unlink shmem if we created it
-            if self.owner && self.pid == unsafe { libc::getpid() } {
+            if self.is_owner() {
                 match shm_unlink(self.unique_id.as_str()) {
                     Ok(_) => {
                         //debug!("shm_unlink()");

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -8,21 +8,20 @@ use crate::*;
 pub struct SharedMemRaw {
     //Os specific data for the mapping
     os_data: os_impl::MapData,
-    is_owner: bool,
 }
 impl SharedMemRaw {
     ///Creates a raw mapping
     pub fn create(unique_id: &str, size: usize) -> Result<SharedMemRaw, SharedMemError> {
         let os_map: os_impl::MapData = os_impl::create_mapping(&unique_id, size)?;
 
-        Ok(SharedMemRaw { os_data: os_map, is_owner: true })
+        Ok(SharedMemRaw { os_data: os_map })
     }
     ///Opens a raw mapping
     pub fn open(unique_id: &str) -> Result<SharedMemRaw, SharedMemError> {
         //Attempt to open the mapping
         let os_map = os_impl::open_mapping(&unique_id)?;
 
-        Ok(SharedMemRaw { os_data: os_map, is_owner: false })
+        Ok(SharedMemRaw { os_data: os_map })
     }
     #[inline]
     ///Returns the size of the raw mapping
@@ -42,7 +41,7 @@ impl SharedMemRaw {
 
     #[inline]
     pub fn is_owner(&self) -> bool {
-        self.is_owner
+        self.os_data.is_owner()
     }
 }
 


### PR DESCRIPTION
Using shared memory for process forks lead to forked children calling shm_unlink. With this change, the ownership takes the pid into consideration. This patch changes the behaviour accordingly.
