### PR TITLE
Added support for serde serializable handles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ exclude = [
     ".travis.yml"
 ]
 
+[features]
+handle = ["serde"]
+
 [dev-dependencies]
 enum_primitive = "0.1"
 
@@ -35,6 +38,7 @@ theban_interval_tree = "0.7"
 memrange = "0.1"
 rand = "0.4"
 shared_memory_derive = { path = "shared_memory_derive", version = "0.10.0" }
+serde = { version = "1.0.104", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.10"

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -1,0 +1,92 @@
+use std::mem;
+use std::sync::Arc;
+
+use serde::{Serialize, Deserialize};
+use serde::de::Deserializer;
+use serde::ser::Serializer;
+
+use crate::{
+    LockType, ReadLockGuard, ReadLockable, SharedMem, SharedMemCast, WriteLockGuard, WriteLockable, SharedMemError,
+};
+
+/// A handle lets you share objects across processes with serde.
+///
+/// This abstracts over shared memory in a way that an object can be serialized
+/// across process boundaries.  This lets you take a `SharedMemCast` object
+/// and serialize it with serde so it can be used from two processes.
+///
+/// This is useful in combination with crates like `procspawn`.
+pub struct Handle<T> {
+    mem: Arc<SharedMem>,
+    _marker: std::marker::PhantomData<T>,
+}
+
+impl<T> Clone for Handle<T> {
+    fn clone(&self) -> Handle<T> {
+        Handle {
+            mem: self.mem.clone(),
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<T: SharedMemCast> Handle<T> {
+    /// Creates a new handle wrapping a shared object.
+    ///
+    // This abstracts over shared memory in a way that an object can be serialized
+    // across process boundaries.  This lets you take a `SharedMemCast` object
+    // and serialize it with serde so it can be used from two processes.
+    /// This is useful in combination with crates like `procspawn`.
+    ///
+    /// This object is locked with a mutex.
+    pub fn new(value: T) -> Result<Handle<T>, SharedMemError> {
+        Handle::with_lock(LockType::Mutex, value)
+    }
+
+    /// Creates a new handle wrapping a shared object.
+    ///
+    /// This handle is locked with the given lock type.
+    pub fn with_lock(lock: LockType, value: T) -> Result<Handle<T>, SharedMemError> {
+        let mem = SharedMem::create(lock, mem::size_of::<T>())?;
+        {
+            let mut data: WriteLockGuard<T> = mem.wlock(0).unwrap();
+            mem::replace(&mut **data, value);
+        }
+        Ok(Handle {
+            mem: Arc::new(mem),
+            _marker: std::marker::PhantomData,
+        })
+    }
+
+    /// Acquires a write lock.
+    pub fn wlock(&self) -> Result<WriteLockGuard<T>, SharedMemError> {
+        self.mem.wlock(0)
+    }
+
+    /// Acquires a read lock.
+    pub fn rlock(&self) -> Result<ReadLockGuard<T>, SharedMemError> {
+        self.mem.rlock(0)
+    }
+}
+
+impl<T: SharedMemCast> Serialize for Handle<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.mem.get_os_path())
+    }
+}
+
+impl<'de, T: SharedMemCast> Deserialize<'de> for Handle<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Handle<T>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: String = String::deserialize(deserializer)?;
+        Ok(Handle {
+            mem: Arc::new(SharedMem::open(&s).unwrap()),
+            _marker: std::marker::PhantomData,
+        })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,11 @@ pub use locks::*;
 mod events;
 pub use events::*;
 
+#[cfg(feature = "handle")]
+mod handle;
+#[cfg(feature = "handle")]
+pub use handle::*;
+
 //Load up the proper OS implementation
 cfg_if! {
     if #[cfg(target_os="windows")] {


### PR DESCRIPTION
This changes the locking to work on `&self` instead of `&mut self` (Fixes #37) and adds serde serializable handles. These can be exchanged between two processes trivially.

This is useful with [`procspawn`](https://docs.rs/procspawn):

```rust
use procspawn::{self, spawn};
use shared_memory::{SharedMemCast, Handle};

#[derive(SharedMemCast)]
struct ShmemStructExample {
    value: u32,
}

fn main() {
    procspawn::init();

    let handle = Handle::new(ShmemStructExample { value: 10 }).unwrap();

    spawn(handle.clone(), |handle| {
        let mut state = handle.wlock().unwrap();
        state.value = 99;
    }).join().unwrap();

    let state = handle.rlock().unwrap();
    assert_eq!(state.value, 99);
}
```