### PR TITLE
Add Shmem functions to get mapped memory as slice

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,4 +223,12 @@ impl Shmem {
     pub fn as_ptr(&self) -> *mut u8 {
         self.mapping.map_ptr
     }
+    /// Return mapping as a byte slice.
+    pub fn as_slice(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.as_ptr(), self.len()) }
+    }
+    /// Return mapping as a mutable byte slice.
+    pub fn as_slice_mut(&mut self) -> &mut [u8] {
+        unsafe { std::slice::from_raw_parts_mut(self.as_ptr(), self.len()) }
+    }
 }


### PR DESCRIPTION
These are useful to actually easily work with the mapped memory within Rust.