### PR TITLE
Emulate POSIX shared memory behavior on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ nix = "0.19"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["ntdef", "winerror", "errhandlingapi", "handleapi", "memoryapi", "winbase", "winnt"] }
+winapi = { version = "0.3", features = ["ntdef", "winerror", "errhandlingapi", "handleapi", "memoryapi", "fileapi", "winbase", "winnt"] }
 
 [dev-dependencies]
 raw_sync = "0.1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,7 @@ pub enum ShmemError {
     MappingIdExists,
     MapCreateFailed(u32),
     MapOpenFailed(u32),
+    WindowsTempDirError(Option<u32>),
     UnknownOsError(u32),
 }
 
@@ -30,6 +31,11 @@ impl std::fmt::Display for ShmemError {
             ShmemError::MappingIdExists => f.write_str("Shared memory OS specific ID already exists"),
             ShmemError::MapCreateFailed(err) => write!(f, "Creating the shared memory failed, os error {}", err),
             ShmemError::MapOpenFailed(err) => write!(f, "Opening the shared memory failed, os error {}", err),
+            ShmemError::WindowsTempDirError(err) => if let Some(err) = err {
+                write!(f, "Finding the Windows Temp directory failed, os error {}", err)
+            } else {
+                write!(f, "Creating a Windows temporary directory failed.",)
+            },
             ShmemError::UnknownOsError(err) => write!(f, "An unexpected OS error occurred, os error {}", err),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,7 @@ impl ShmemConf {
             None => return Err(ShmemError::NoLinkOrOsId),
         };
 
-        let mapping = os_impl::open_mapping(os_id)?;
+        let mapping = os_impl::open_mapping(os_id, self.size)?;
 
         self.size = mapping.map_size;
         self.owner = false;
@@ -204,7 +204,12 @@ impl Shmem {
     ///
     /// Warning : You must ensure at least one process owns the mapping in order to ensure proper cleanup code is ran
     pub fn set_owner(&mut self, is_owner: bool) -> bool {
-        #[cfg(any(target_os = "freebsd", target_os = "linux", target_os = "macos"))]
+        #[cfg(any(
+            target_os = "freebsd",
+            target_os = "linux",
+            target_os = "macos",
+            target_os = "windows"
+        ))]
         self.mapping.set_owner(is_owner);
 
         let prev_val = self.config.owner;

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -124,7 +124,7 @@ pub fn create_mapping(unique_id: &str, map_size: usize) -> Result<MapData, Shmem
 }
 
 /// Opens an existing mapping specified by its uid
-pub fn open_mapping(unique_id: &str) -> Result<MapData, ShmemError> {
+pub fn open_mapping(unique_id: &str, _map_size: usize) -> Result<MapData, ShmemError> {
     //Open shared memory
     let shmem_fd = match shm_open(
         unique_id,

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,28 +1,42 @@
 use ::winapi::{
     shared::{
+        minwindef::{DWORD, LPVOID, MAX_PATH},
         ntdef::{FALSE, NULL},
-        winerror::ERROR_ALREADY_EXISTS,
+        winerror::{ERROR_ALREADY_EXISTS, ERROR_FILE_EXISTS, ERROR_FILE_NOT_FOUND},
     },
     um::{
         errhandlingapi::GetLastError,
+        fileapi::{
+            CreateFileW, GetTempPathW, SetFileInformationByHandle, CREATE_NEW, FILE_RENAME_INFO,
+            OPEN_EXISTING,
+        },
         handleapi::{CloseHandle, INVALID_HANDLE_VALUE},
         memoryapi::{
             CreateFileMappingW, MapViewOfFile, OpenFileMappingW, UnmapViewOfFile, VirtualQuery,
             FILE_MAP_READ, FILE_MAP_WRITE,
         },
-        winnt::{HANDLE, MEMORY_BASIC_INFORMATION, PAGE_READWRITE},
+        minwinbase::FileRenameInfo,
+        winbase::FILE_FLAG_DELETE_ON_CLOSE,
+        winnt::{
+            DELETE, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+            GENERIC_READ, GENERIC_WRITE, HANDLE, MEMORY_BASIC_INFORMATION, PAGE_READWRITE, WCHAR,
+        },
     },
 };
 
 use crate::ShmemError;
 
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
+use std::io::ErrorKind;
 use std::iter::once;
 use std::mem::size_of;
-use std::os::windows::ffi::OsStrExt;
+use std::os::windows::ffi::{OsStrExt, OsStringExt};
+use std::path::PathBuf;
 use std::ptr::null_mut;
 
 pub struct MapData {
+    owner: bool,
+    file_handle: HANDLE,
     ///The handle to our open mapping
     map_handle: HANDLE,
 
@@ -50,6 +64,140 @@ impl Drop for MapData {
                 CloseHandle(self.map_handle);
             }
         }
+
+        // Close the handle to the backing file
+        if self.file_handle as *mut _ != NULL {
+            unsafe {
+                CloseHandle(self.file_handle);
+            }
+        }
+
+        // Inspired by the boost implementation at
+        // https://github.com/boostorg/interprocess/blob/140b50efb3281fa3898f3a4cf939cfbda174718f/include/boost/interprocess/detail/win32_api.hpp
+        // Emulate POSIX behavior by
+        // 1. Opening the backing file with `FILE_FLAG_DELETE_ON_CLOSE`, causing it to be
+        // deleted when all its handles have been closed.
+        // 2. Renaming the backing file to prevent future access/opening.
+        // Once this has run, existing file/mapping handles remain usable but the file is
+        // deleted once all handles have been closed and no new handles can be opened
+        // because the file has been renamed. This matches the behavior of shm_unlink()
+        // on unix.
+        if self.owner {
+            let mut base_path = get_tmp_dir().unwrap();
+            base_path.push(self.unique_id.trim_start_matches("/"));
+            // Encode the file path as a null-terminated UTF-16 sequence
+            let file_path: Vec<WCHAR> = base_path
+                .as_os_str()
+                .encode_wide()
+                .chain(OsStr::new("\0").encode_wide())
+                .collect();
+            let handle = unsafe {
+                CreateFileW(
+                    file_path.as_ptr(),
+                    GENERIC_READ | GENERIC_WRITE | DELETE,
+                    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                    null_mut(),
+                    OPEN_EXISTING,
+                    FILE_FLAG_DELETE_ON_CLOSE,
+                    NULL,
+                )
+            };
+            if handle == INVALID_HANDLE_VALUE {
+                let last_error = unsafe { GetLastError() };
+                Err(ShmemError::UnknownOsError(last_error)).unwrap()
+            }
+            base_path.pop();
+            base_path.push(format!("{}_delete", self.unique_id.trim_start_matches("/")));
+            let new_filename: Vec<WCHAR> = base_path
+                .as_os_str()
+                .encode_wide()
+                .chain(OsStr::new("\0").encode_wide())
+                .collect();
+            // Allocate bytes to hold `rename_info` plus `new_filename` in the `FileName` field,
+            // see https://github.com/retep998/winapi-rs/issues/231
+            // `- 1` takes care of double-counting one element in `new_filename`
+            let buf_size =
+                size_of::<FILE_RENAME_INFO>() + size_of::<WCHAR>() * (new_filename.len() - 1);
+            let mut buf = vec![0u8; buf_size];
+            let rename_info = unsafe { &mut *(buf.as_mut_ptr() as *mut FILE_RENAME_INFO) };
+            // See https://stackoverflow.com/questions/36450222/moving-a-file-using-setfileinformationbyhandle
+            // for the required inputs.
+            rename_info.ReplaceIfExists = 1;
+            rename_info.RootDirectory = NULL;
+            // Length without terminating null. Is ignored according to the link above.
+            rename_info.FileNameLength = (size_of::<WCHAR>() * (new_filename.len() - 0)) as DWORD;
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    new_filename.as_ptr(),
+                    rename_info.FileName.as_mut_ptr(),
+                    new_filename.len(),
+                );
+            }
+            unsafe {
+                debug_assert_eq!(
+                    new_filename.as_slice(),
+                    std::slice::from_raw_parts(rename_info.FileName.as_ptr(), new_filename.len())
+                );
+            };
+            // Rename the backing file
+            if unsafe {
+                SetFileInformationByHandle(
+                    handle,
+                    FileRenameInfo,
+                    rename_info as *mut _ as LPVOID,
+                    buf_size as DWORD,
+                )
+            } == 0
+            {
+                let last_error = unsafe { GetLastError() };
+                Err(ShmemError::UnknownOsError(last_error)).unwrap()
+            }
+            // Close the file handle
+            if unsafe { CloseHandle(handle) } == 0 {
+                let last_error = unsafe { GetLastError() };
+                Err(ShmemError::UnknownOsError(last_error)).unwrap()
+            }
+        }
+    }
+}
+
+impl MapData {
+    pub fn set_owner(&mut self, is_owner: bool) -> bool {
+        let prev_val = self.owner;
+        self.owner = is_owner;
+        prev_val
+    }
+}
+
+/// Returns the path to a temporary directory in which to store files backing the shared memory. If it
+/// doesn't exist, the directory is created.
+fn get_tmp_dir() -> Result<PathBuf, ShmemError> {
+    let mut buffer: [WCHAR; MAX_PATH] = [0; MAX_PATH];
+    let len = unsafe { GetTempPathW(MAX_PATH as DWORD, buffer.as_mut_ptr()) };
+    let mut path: PathBuf = if len == 0 {
+        let last_error = unsafe { GetLastError() };
+        return Err(ShmemError::WindowsTempDirError(Some(last_error)));
+    } else if len > MAX_PATH as DWORD {
+        let mut buffer = Vec::with_capacity(len as usize);
+        let new_len = unsafe { GetTempPathW(len, buffer.as_mut_ptr()) };
+        if new_len == 0 {
+            let last_error = unsafe { GetLastError() };
+            return Err(ShmemError::WindowsTempDirError(Some(last_error)));
+        } else if new_len > len {
+            unreachable!()
+        } else {
+            OsString::from_wide(&buffer[..new_len as usize]).into()
+        }
+    } else {
+        OsString::from_wide(&buffer[..len as usize]).into()
+    };
+    path.push("shared_memory-rs");
+    match std::fs::create_dir(path.as_path()) {
+        Ok(_) => Ok(path),
+        Err(err) => match err.kind() {
+            ErrorKind::AlreadyExists => Ok(path),
+            _ => Err(ShmemError::WindowsTempDirError(None)),
+        },
     }
 }
 
@@ -57,11 +205,42 @@ impl Drop for MapData {
 pub fn create_mapping(unique_id: &str, map_size: usize) -> Result<MapData, ShmemError> {
     //In addition to being the return value, the Drop impl of this helps clean up on failure
     let mut new_map: MapData = MapData {
+        owner: true,
+        file_handle: NULL,
         unique_id: String::from(unique_id),
         map_handle: NULL,
         map_size,
         map_ptr: null_mut(),
     };
+
+    // Create file to back the shared memory
+    let mut base_path = get_tmp_dir()?;
+    base_path.push(unique_id.trim_start_matches("/"));
+    // Encode the file path as a null-terminated UTF-16 sequence
+    let file_path: Vec<WCHAR> = base_path
+        .as_os_str()
+        .encode_wide()
+        .chain(OsStr::new("\0").encode_wide())
+        .collect();
+    new_map.file_handle = unsafe {
+        CreateFileW(
+            file_path.as_ptr(),
+            GENERIC_READ | GENERIC_WRITE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            null_mut(),
+            CREATE_NEW,
+            FILE_ATTRIBUTE_NORMAL,
+            NULL,
+        )
+    };
+    if new_map.file_handle == INVALID_HANDLE_VALUE {
+        let last_error = unsafe { GetLastError() };
+        if last_error == ERROR_FILE_EXISTS {
+            return Err(ShmemError::MappingIdExists);
+        } else {
+            return Err(ShmemError::MapCreateFailed(last_error));
+        }
+    }
 
     //Create Mapping
     new_map.map_handle = unsafe {
@@ -69,7 +248,7 @@ pub fn create_mapping(unique_id: &str, map_size: usize) -> Result<MapData, Shmem
         let low_size: u32 = (map_size as u64 & 0xFFFF_FFFF_u64) as u32;
         let unique_id: Vec<u16> = OsStr::new(unique_id).encode_wide().chain(once(0)).collect();
         CreateFileMappingW(
-            INVALID_HANDLE_VALUE,
+            new_map.file_handle,
             null_mut(),
             PAGE_READWRITE,
             high_size,
@@ -97,9 +276,11 @@ pub fn create_mapping(unique_id: &str, map_size: usize) -> Result<MapData, Shmem
 }
 
 //Opens an existing mapping specified by its uid
-pub fn open_mapping(unique_id: &str) -> Result<MapData, ShmemError> {
+pub fn open_mapping(unique_id: &str, map_size: usize) -> Result<MapData, ShmemError> {
     //In addition to being the return value, the Drop impl of this helps clean up on failure
     let mut new_map: MapData = MapData {
+        owner: false,
+        file_handle: NULL,
         unique_id: String::from(unique_id),
         map_handle: NULL,
         map_size: 0,
@@ -107,8 +288,15 @@ pub fn open_mapping(unique_id: &str) -> Result<MapData, ShmemError> {
     };
 
     //Open existing mapping
+    // See https://docs.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-createfilemappingw
+    // for why we don't need to flush the file views to disk to share the same memory between processes.
+    // "...file views derived from any file mapping object that is backed by the same file are coherent or
+    // identical at a specific time."
     new_map.map_handle = unsafe {
         let unique_id: Vec<u16> = OsStr::new(unique_id).encode_wide().chain(once(0)).collect();
+        // This call can fail with `ERROR_FILE_NOT_FOUND` if the mapping has been deleted because there
+        // are no active handles. In that case we fall back to getting a new handle from the backing
+        // file, see below.
         OpenFileMappingW(
             FILE_MAP_READ | FILE_MAP_WRITE,
             FALSE as _,
@@ -117,7 +305,59 @@ pub fn open_mapping(unique_id: &str) -> Result<MapData, ShmemError> {
     };
     if new_map.map_handle as *mut _ == NULL {
         let last_error = unsafe { GetLastError() };
-        return Err(ShmemError::MapOpenFailed(last_error));
+        if last_error == ERROR_FILE_NOT_FOUND {
+            // The mapping doesn't exist, create one from the backing file.
+            let mut base_path = get_tmp_dir().unwrap();
+            base_path.push(unique_id.trim_start_matches("/"));
+            // Encode the file path as a null-terminated UTF-16 sequence
+            let file_path: Vec<WCHAR> = base_path
+                .as_os_str()
+                .encode_wide()
+                .chain(OsStr::new("\0").encode_wide())
+                .collect();
+            new_map.file_handle = unsafe {
+                CreateFileW(
+                    file_path.as_ptr(),
+                    GENERIC_READ | GENERIC_WRITE,
+                    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                    null_mut(),
+                    OPEN_EXISTING,
+                    FILE_ATTRIBUTE_NORMAL,
+                    NULL,
+                )
+            };
+            if new_map.file_handle == INVALID_HANDLE_VALUE {
+                // The backing file doesn't exist.
+                let last_error = unsafe { GetLastError() };
+                return Err(ShmemError::MapOpenFailed(last_error));
+            } else {
+                new_map.map_handle = unsafe {
+                    let high_size: u32 =
+                        ((map_size as u64 & 0xFFFF_FFFF_0000_0000_u64) >> 32) as u32;
+                    let low_size: u32 = (map_size as u64 & 0xFFFF_FFFF_u64) as u32;
+                    let unique_id: Vec<u16> =
+                        OsStr::new(unique_id).encode_wide().chain(once(0)).collect();
+                    CreateFileMappingW(
+                        new_map.file_handle,
+                        null_mut(),
+                        PAGE_READWRITE,
+                        high_size,
+                        low_size,
+                        unique_id.as_ptr(),
+                    )
+                };
+                // Unlike in `create_mapping` no need to check for `ERROR_ALREADY_EXISTS`, `CreateFileMappingW`
+                // returns the handle to the existing object if one exists. This might be the case if processes
+                // race for mapping creation between here and the `OpenFileMappingW` call above.
+                if new_map.map_handle == NULL {
+                    let last_error = unsafe { GetLastError() };
+                    return Err(ShmemError::MapCreateFailed(last_error));
+                }
+            }
+        } else {
+            // `OpenFileMappingW` has failed with something else than `ERROR_FILE_NOT_FOUND`.
+            return Err(ShmemError::MapOpenFailed(last_error));
+        }
     }
 
     //Map mapping into address space

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -86,7 +86,7 @@ impl Drop for MapData {
         // on unix.
         if self.owner {
             let mut base_path = get_tmp_dir().unwrap();
-            base_path.push(self.unique_id.trim_start_matches("/"));
+            base_path.push(self.unique_id.trim_start_matches('/'));
             // Encode the file path as a null-terminated UTF-16 sequence
             let file_path: Vec<WCHAR> = base_path
                 .as_os_str()
@@ -121,7 +121,7 @@ impl Drop for MapData {
                 base_path.pop();
                 base_path.push(format!(
                     "{}_deleted",
-                    self.unique_id.trim_start_matches("/")
+                    self.unique_id.trim_start_matches('/')
                 ));
                 let new_filename: Vec<WCHAR> = base_path
                     .as_os_str()
@@ -141,7 +141,7 @@ impl Drop for MapData {
                 rename_info.RootDirectory = NULL;
                 // Length without terminating null. Is ignored according to the link above.
                 rename_info.FileNameLength =
-                    (size_of::<WCHAR>() * (new_filename.len() - 0)) as DWORD;
+                    (size_of::<WCHAR>() * (new_filename.len() - 1)) as DWORD;
                 unsafe {
                     std::ptr::copy_nonoverlapping(
                         new_filename.as_ptr(),
@@ -240,7 +240,7 @@ pub fn create_mapping(unique_id: &str, map_size: usize) -> Result<MapData, Shmem
 
     // Create file to back the shared memory
     let mut base_path = get_tmp_dir()?;
-    base_path.push(unique_id.trim_start_matches("/"));
+    base_path.push(unique_id.trim_start_matches('/'));
     // Encode the file path as a null-terminated UTF-16 sequence
     let file_path: Vec<WCHAR> = base_path
         .as_os_str()
@@ -324,7 +324,7 @@ pub fn open_mapping(unique_id: &str, map_size: usize) -> Result<MapData, ShmemEr
     // succeed even if the mmapped file has been renamed when dropping owning `MapData` if other mappings are
     // still open. Posix shared memory doesn't allow that, see the `shm_unlink()` docs.
     let mut base_path = get_tmp_dir().unwrap();
-    base_path.push(unique_id.trim_start_matches("/"));
+    base_path.push(unique_id.trim_start_matches('/'));
     // Encode the file path as a null-terminated UTF-16 sequence
     let file_path: Vec<WCHAR> = base_path
         .as_os_str()

--- a/tests/posix_semantics.rs
+++ b/tests/posix_semantics.rs
@@ -1,11 +1,12 @@
 use shared_memory::ShmemConf;
 
 #[test]
-fn main() {
+fn persistence() {
     let os_id = {
         let mut shmem = ShmemConf::new().size(4096).create().unwrap();
         shmem.set_owner(false);
         String::from(shmem.get_os_id())
     };
-    let _shmem = ShmemConf::new().os_id(os_id).open().unwrap();
+    let mut shmem = ShmemConf::new().os_id(os_id).open().unwrap();
+    shmem.set_owner(true);
 }

--- a/tests/posix_semantics.rs
+++ b/tests/posix_semantics.rs
@@ -1,4 +1,6 @@
 use shared_memory::ShmemConf;
+use std::sync::mpsc::channel;
+use std::thread;
 
 #[test]
 fn persistence() {
@@ -9,4 +11,77 @@ fn persistence() {
     };
     let mut shmem = ShmemConf::new().os_id(os_id).open().unwrap();
     shmem.set_owner(true);
+}
+
+#[test]
+fn posix_behavior() {
+    let (tx_a, rx_a) = channel();
+    let (tx_b, rx_b) = channel();
+    let (tx_c, rx_c) = channel();
+
+    let thread_a = thread::Builder::new()
+        .name(String::from("A"))
+        .spawn(move || {
+            let os_id = {
+                let shmem = ShmemConf::new().size(4096).create().unwrap();
+                let os_id = String::from(shmem.get_os_id());
+                // Creating two `Shmem`s with the same `os_id` should fail
+                assert!(ShmemConf::new().size(4096).os_id(&os_id).create().is_err());
+                tx_b.send(os_id.clone()).unwrap();
+                tx_c.send(os_id.clone()).unwrap();
+                // Wait for threads B and C to confirm they have created their instances.
+                rx_a.recv().unwrap();
+                rx_a.recv().unwrap();
+                os_id
+                // Owned shmem drops here after a second owned instance has been
+                // dropped in thread B.
+            };
+            // Should not be able to reopen shared memory after an owned instance
+            // has been dropped in thread B.
+            // assert!(ShmemConf::new().size(4096).os_id(os_id).open().is_err());
+            // Tell thread C to drop the unowned instance.
+            tx_c.send(String::new()).unwrap();
+        })
+        .unwrap();
+    let thread_b = thread::Builder::new()
+        .name(String::from("B"))
+        .spawn({
+            let tx_a = tx_a.clone();
+            move || {
+                let existing_os_id = rx_b.recv().unwrap();
+                // Creating two `Shmem`s with the same `os_id` should fail
+                assert!(ShmemConf::new()
+                    .size(4096)
+                    .os_id(&existing_os_id)
+                    .create()
+                    .is_err());
+                {
+                    // Should be able to open the existing shared memory
+                    let mut shmem = ShmemConf::new().os_id(&existing_os_id).open().unwrap();
+                    shmem.set_owner(true);
+                    tx_a.send(String::new()).unwrap();
+                    // When the owning shmem is dropped here, we
+                    // 1. should be able to still drop the original shared memory in thread A.
+                    // 2. should not be able to reopen it with the same name in thread A, even
+                    // if an instance is kept alive in thread C.
+                }
+            }
+        })
+        .unwrap();
+    let thread_c = thread::Builder::new()
+        .name(String::from("C"))
+        .spawn(move || {
+            // This thread keeps a shared memory instance alive until it's told to
+            // drop it.
+            let existing_os_id = rx_c.recv().unwrap();
+            let _shmem = ShmemConf::new().os_id(&existing_os_id).open().unwrap();
+            // Indicate to thread A that the instance has been created.
+            tx_a.send(String::new()).unwrap();
+            // Shut down signal.
+            rx_c.recv().unwrap();
+        })
+        .unwrap();
+    thread_a.join().unwrap();
+    thread_b.join().unwrap();
+    thread_c.join().unwrap();
 }

--- a/tests/posix_semantics.rs
+++ b/tests/posix_semantics.rs
@@ -1,0 +1,11 @@
+use shared_memory::ShmemConf;
+
+#[test]
+fn main() {
+    let os_id = {
+        let mut shmem = ShmemConf::new().size(4096).create().unwrap();
+        shmem.set_owner(false);
+        String::from(shmem.get_os_id())
+    };
+    let _shmem = ShmemConf::new().os_id(os_id).open().unwrap();
+}


### PR DESCRIPTION
`Shmem` currently behaves differently on Windows than Unix. Specifically, `Shmem::set_owner` has no effect on the underlying memory object on Windows, as the standard Windows shared file mapping doesn't allow persistence. This means that dropping a unique `Shmem` will destroy the shared memory even when `Shmem::is_owner` returns false. This clashes with POSIX behaviour, which persists the memory unless [`shm_unlink()`](https://www.man7.org/linux/man-pages/man3/shm_unlink.3.html) is called and allows reopening even when all handles have previously been closed.

This PR unifies shared memory behaviour on Windows and Unix and adds a test to check for compliance. It follows the [C++ Boost](https://www.boost.org/doc/libs/1_75_0/doc/html/interprocess/sharedmemorybetweenprocesses.html#interprocess.sharedmemorybetweenprocesses.sharedmemory.emulation) implementation of creating a file to back the shared memory which is renamed and marked for deletion when an owning `Shmem` drops, but persists otherwise. `Shmem::set_owner` stops being a no-op on Windows and now behaves as expected.