### PR TITLE
adding a simple backoff mechanism for macos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,5 +50,5 @@ winapi = { version = "0.3", features = [
 [dev-dependencies]
 raw_sync = "0.1"
 clap = "2.33"
-env_logger = "0"
-log = "0"
+env_logger = "0.9"
+log = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,7 +239,7 @@ impl ShmemConf {
         let mapping = loop {
             retry_counter -= 1;
             match os_impl::open_mapping(os_id, self.size) {
-                Err(e) if retry_counter <= 0 => return Err(e.into()),
+                Err(e) if retry_counter <= 0 => return Err(e),
                 Ok(mapping) => break mapping,
                 Err(_) => {
                     std::thread::yield_now();


### PR DESCRIPTION
As far as I was able to test, fixes #71
The backoff is currently only for macos. Since the error was already a bit hard to trigger, I think yielding 10 times should be enough.