### PR TITLE
Add Clone for ShmemConf

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ cfg_if! {
     }
 }
 
+#[derive(Clone)]
 /// Struct used to configure different parameters before creating a shared memory mapping
 pub struct ShmemConf {
     owner: bool,


### PR DESCRIPTION
```rust
	let shm_conf = ShmemConf::new()
		.size(4096)
		.os_id("foo")
		.flink("bar");
	let mut shm = shm_conf
		.clone()
		.create()
		.or_else(|_| shm_conf.open())
		.unwrap();
```
It may be useful in occasions like this.