### PR TITLE
fix: remove 'release_max_level_off' default feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,11 @@ categories = [
 exclude = ["ci/*", ".github/*"]
 
 [features]
-default = ["log/release_max_level_off"]
 
 [dependencies]
 cfg-if = "1.0"
 rand = "0.8"
-log = { version = "0.4", optional = true }
+log = "0.4"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.23"


### PR DESCRIPTION
Seems like adding:
```toml
[features]
default = ["log/release_max_level_off"]
```
is turning off logging for everything downstream 😅 

The log crate docs recommends that libraries should not set any MAX level since that is global ([link](https://docs.rs/log/latest/log/#compile-time-filters))

I tried just removing that default feature and the optional dep on log. 