### PR TITLE
Upgrade nix to 0.24, limit features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ rand = "0.8"
 log = { version = "0.4", optional = true }
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.23"
+nix = { version = "0.24", default-features = false, features = ["fs", "mman"] }
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
This removes memoffset as an indirect dependency, and decreases build times.

See also: https://github.com/elast0ny/raw_sync-rs/pull/27