### PR TITLE
Windows CreateFileMapping arguments

### DIFF
--- a/examples/mutex.rs
+++ b/examples/mutex.rs
@@ -57,7 +57,7 @@ fn increment_value(shmem_flink: &str, thread_num: usize) {
     let is_init: &mut AtomicU8;
 
     unsafe {
-        is_init = &mut *(raw_ptr as *mut u8 as *mut AtomicU8);
+        is_init = &mut *(raw_ptr as *mut AtomicU8);
         raw_ptr = raw_ptr.add(8);
     };
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -169,7 +169,7 @@ fn new_map(
             let low_size: u32 = (map_size as u64 & 0xFFFF_FFFF_u64) as u32;
             trace!(
                 "CreateFileMapping({:?}, NULL, {:X}, {}, {}, '{}')",
-                HANDLE(f.as_raw_handle() as _),
+                INVALID_HANDLE_VALUE,
                 PAGE_READWRITE.0,
                 high_size,
                 low_size,
@@ -177,7 +177,7 @@ fn new_map(
             );
 
             match CreateFileMapping(
-                HANDLE(f.as_raw_handle() as _),
+                INVALID_HANDLE_VALUE,
                 None,
                 PAGE_READWRITE,
                 high_size,

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,6 +1,6 @@
 use std::fs::{File, OpenOptions};
 use std::io::ErrorKind;
-use std::os::windows::{fs::OpenOptionsExt, io::AsRawHandle};
+use std::os::windows::fs::OpenOptionsExt;
 use std::path::PathBuf;
 
 use crate::{log::*, ShmemConf};
@@ -73,7 +73,7 @@ impl Drop for MapData {
             {
                 Ok(_) => {
                     // 2. Rename file to prevent further use
-                    base_path.push(&format!(
+                    base_path.push(format!(
                         "{}_deleted",
                         self.unique_id.trim_start_matches('/')
                     ));


### PR DESCRIPTION
fix CreateFileMapping arguments: use default pagefile instead of real file on disk