### PR TITLE
Adjust persistency on Windows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,9 +27,6 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      - name: Setup rust-cache
-        uses: Swatinem/rust-cache@v2
-
       - name: Check Code Format
         uses: actions-rs/cargo@v1.0.3
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,6 +43,7 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: build
+          args: --features log
 
       - name: Set RUST_LOG
         run: echo "RUST_LOG=trace" >> $GITHUB_ENV

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,6 +44,9 @@ jobs:
         with:
           command: build
 
+      - name: Set RUST_LOG
+        run: echo "RUST_LOG=trace" >> $GITHUB_ENV
+
       - name: Tests
         uses: actions-rs/cargo@v1.0.3
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,6 +27,9 @@ jobs:
           override: true
           components: rustfmt, clippy
 
+      - name: Setup rust-cache
+        uses: Swatinem/rust-cache@v2
+
       - name: Check Code Format
         uses: actions-rs/cargo@v1.0.3
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,14 +44,13 @@ jobs:
         with:
           command: build
 
-      - name: Set RUST_LOG
-        run: echo "RUST_LOG=trace" >> $GITHUB_ENV
-
       - name: Tests
         uses: actions-rs/cargo@v1.0.3
+        env:
+          RUST_LOG: "trace"
         with:
           command: test
-          args: --features logging -- --nocapture
+          args: --all-features -- --nocapture
 
       - name: Examples
         uses: actions-rs/cargo@v1.0.3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,6 +51,7 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: test
+          args: -- --nocapture
 
       - name: Examples
         uses: actions-rs/cargo@v1.0.3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: build
-          args: --features log
+          args: --features logging
 
       - name: Set RUST_LOG
         run: echo "RUST_LOG=trace" >> $GITHUB_ENV

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,7 +43,6 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: build
-          args: --features logging
 
       - name: Set RUST_LOG
         run: echo "RUST_LOG=trace" >> $GITHUB_ENV
@@ -52,7 +51,7 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: test
-          args: -- --nocapture
+          args: --features logging -- --nocapture
 
       - name: Examples
         uses: actions-rs/cargo@v1.0.3

--- a/examples/mutex.rs
+++ b/examples/mutex.rs
@@ -57,7 +57,7 @@ fn increment_value(shmem_flink: &str, thread_num: usize) {
     let is_init: &mut AtomicU8;
 
     unsafe {
-        is_init = &mut *(raw_ptr as *mut u8 as *mut AtomicU8);
+        is_init = &mut *(raw_ptr as *mut AtomicU8);
         raw_ptr = raw_ptr.add(8);
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ impl ShmemConf {
                 // Generate random ID until one works
                 loop {
                     let cur_id = format!("/shmem_{:X}", rand::random::<u64>());
-                    match os_impl::create_mapping(&cur_id, self.size) {
+                    match os_impl::create_mapping(&cur_id, self.size, &self.ext) {
                         Err(ShmemError::MappingIdExists) => continue,
                         Ok(m) => break m,
                         Err(e) => {
@@ -127,7 +127,7 @@ impl ShmemConf {
                     };
                 }
             }
-            Some(ref specific_id) => os_impl::create_mapping(specific_id, self.size)?,
+            Some(ref specific_id) => os_impl::create_mapping(specific_id, self.size, &self.ext)?,
         };
         debug!("Created shared memory mapping '{}'", mapping.unique_id);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ cfg_if! {
         compile_error!("shared_memory isnt implemented for this platform...");
     }
 }
+pub use os_impl::ShmemConfExt;
 
 #[derive(Clone, Default)]
 /// Struct used to configure different parameters before creating a shared memory mapping
@@ -97,6 +98,12 @@ impl ShmemConf {
     /// Sets the size of the mapping that will be used in `create()`
     pub fn size(mut self, size: usize) -> Self {
         self.size = size;
+        self
+    }
+
+    /// Sets the platform-specific parameters
+    pub fn ext(mut self, ext: os_impl::ShmemConfExt) -> Self {
+        self.ext = ext;
         self
     }
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -81,7 +81,11 @@ impl MapData {
 }
 
 /// Creates a mapping specified by the uid and size
-pub fn create_mapping(unique_id: &str, map_size: usize) -> Result<MapData, ShmemError> {
+pub fn create_mapping(
+    unique_id: &str,
+    map_size: usize,
+    _: &ShmemConfExt,
+) -> Result<MapData, ShmemError> {
     //Create shared memory file descriptor
     debug!("Creating persistent mapping at {}", unique_id);
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -164,7 +164,7 @@ fn open_map(unique_id: &str, allow_raw: bool) -> Result<MapData, ShmemError> {
         }
         Err(e) => {
             if !allow_raw {
-                return Err(ShmemError::MapOpenFailed(ERROR_FILE_NOT_FOUND.0));
+                return Err(ShmemError::MapOpenFailed(e.win32_error().unwrap().0));
             }
 
             // This may be a mapping that isnt managed by this crate
@@ -304,7 +304,7 @@ pub fn create_mapping(unique_id: &str, map_size: usize) -> Result<MapData, Shmem
 //Opens an existing mapping specified by its uid
 pub fn open_mapping(
     unique_id: &str,
-    map_size: usize,
+    _map_size: usize,
     ext: &ShmemConfExt,
 ) -> Result<MapData, ShmemError> {
     open_map(unique_id, ext.allow_raw)

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -11,12 +11,19 @@ use crate::ShmemError;
 #[derive(Clone, Default)]
 pub struct ShmemConfExt {
     allow_raw: bool,
+    suppress_persistency: bool,
 }
 
 impl ShmemConf {
     /// If set to true, enables openning raw shared memory that is not managed by this crate
     pub fn allow_raw(mut self, allow: bool) -> Self {
         self.ext.allow_raw = allow;
+        self
+    }
+
+    /// If set to true, the persistency of the object will be suppressed
+    pub fn suppress_persistency(mut self, suppress: bool) -> Self {
+        self.ext.suppress_persistency = suppress;
         self
     }
 }
@@ -131,55 +138,45 @@ fn get_tmp_dir() -> Result<PathBuf, ShmemError> {
     }
 }
 
-fn open_map(unique_id: &str, allow_raw: bool) -> Result<MapData, ShmemError> {
+fn open_map(unique_id: &str, ext: &ShmemConfExt) -> Result<MapData, ShmemError> {
     // Create file to back the shared memory
     let mut file_path = get_tmp_dir()?;
     file_path.push(unique_id.trim_start_matches('/'));
     debug!("Opening persistent_file at {}", file_path.to_string_lossy());
 
-    let (persistent_file, map_h) = match OpenOptions::new()
-        .read(true)
-        .write(true)
-        .share_mode((FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE).0)
-        .attributes((FILE_ATTRIBUTE_TEMPORARY).0)
-        .create(false)
-        .open(&file_path)
-    {
-        Ok(f) => {
-            //Open Mapping using persistent file
-            debug!("Openning memory mapping",);
-
-            trace!(
-                "OpenFileMappingW({:?}, {}, '{}')",
-                FILE_MAP_ALL_ACCESS,
-                false,
-                unique_id,
-            );
-            match OpenFileMapping(FILE_MAP_ALL_ACCESS, false, unique_id) {
-                Ok(h) => (Some(f), h),
-                Err(e) => {
-                    return Err(ShmemError::MapOpenFailed(e.win32_error().unwrap().0));
+    let persistent_file = match ext.suppress_persistency {
+        false => match OpenOptions::new()
+            .read(true)
+            .write(true)
+            .share_mode((FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE).0)
+            .attributes((FILE_ATTRIBUTE_TEMPORARY).0)
+            .create(false)
+            .open(&file_path)
+        {
+            Ok(f) => Some(f),
+            Err(e) => {
+                if !allow_raw {
+                    return Err(ShmemError::MapOpenFailed(e.raw_os_error().unwrap() as _));
                 }
             }
-        }
-        Err(e) => {
-            if !allow_raw {
-                return Err(ShmemError::MapOpenFailed(e.raw_os_error().unwrap() as _));
-            }
+        },
+        true => None,
+    };
 
-            // This may be a mapping that isnt managed by this crate
-            // Try to open the mapping without any backing file
-            trace!(
-                "OpenFileMappingW({:?}, {}, '{}')",
-                FILE_MAP_ALL_ACCESS,
-                false,
-                unique_id,
-            );
-            match OpenFileMapping(FILE_MAP_ALL_ACCESS, false, unique_id) {
-                Ok(h) => (None, h),
-                Err(e) => {
-                    return Err(ShmemError::MapOpenFailed(e.win32_error().unwrap().0));
-                }
+    let map_h = {
+        //Open Mapping
+        debug!("Opening memory mapping",);
+
+        trace!(
+            "OpenFileMappingW({:?}, {}, '{}')",
+            FILE_MAP_ALL_ACCESS,
+            false,
+            unique_id,
+        );
+        match OpenFileMapping(FILE_MAP_ALL_ACCESS, false, unique_id) {
+            Ok(h) => (Some(f), h),
+            Err(e) => {
+                return Err(ShmemError::MapOpenFailed(e.win32_error().unwrap().0));
             }
         }
     };
@@ -214,59 +211,44 @@ fn open_map(unique_id: &str, allow_raw: bool) -> Result<MapData, ShmemError> {
     })
 }
 
-fn new_map(unique_id: &str, map_size: usize) -> Result<MapData, ShmemError> {
-    // Create file to back the shared memory
-    let mut file_path = get_tmp_dir()?;
-    file_path.push(unique_id.trim_start_matches('/'));
-    debug!(
-        "Creating persistent_file at {}",
-        file_path.to_string_lossy()
-    );
+fn create_file_mapping(
+    unique_id: &str,
+    map_size: usize,
+    persistent_file: Option<File>,
+) -> Result<MapData, ShmemError> {
+    let map_h = {
+        debug!("Creating memory mapping",);
+        let h_handle = persistent_file
+            .map(|f| f.as_raw_handle() as _)
+            .unwrap_or(INVALID_HANDLE_VALUE);
+        let high_size: u32 = ((map_size as u64 & 0xFFFF_FFFF_0000_0000_u64) >> 32) as u32;
+        let low_size: u32 = (map_size as u64 & 0xFFFF_FFFF_u64) as u32;
+        trace!(
+            "CreateFileMapping({:?}, NULL, {:X}, {}, {}, '{}')",
+            h_handle,
+            PAGE_READWRITE.0,
+            high_size,
+            low_size,
+            unique_id,
+        );
 
-    let (persistent_file, map_h) = match OpenOptions::new()
-        .read(true)
-        .write(true)
-        .share_mode((FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE).0)
-        .attributes((FILE_ATTRIBUTE_TEMPORARY).0)
-        .create_new(true)
-        .open(&file_path)
-    {
-        Ok(f) => {
-            //Create Mapping using persistent file
-            debug!("Creating memory mapping",);
-            let high_size: u32 = ((map_size as u64 & 0xFFFF_FFFF_0000_0000_u64) >> 32) as u32;
-            let low_size: u32 = (map_size as u64 & 0xFFFF_FFFF_u64) as u32;
-            trace!(
-                "CreateFileMapping({:?}, NULL, {:X}, {}, {}, '{}')",
-                INVALID_HANDLE_VALUE,
-                PAGE_READWRITE.0,
-                high_size,
-                low_size,
-                unique_id,
-            );
-
-            match CreateFileMapping(
-                INVALID_HANDLE_VALUE,
-                None,
-                PAGE_READWRITE,
-                high_size,
-                low_size,
-                unique_id,
-            ) {
-                Ok(v) => (Some(f), v),
-                Err(e) => {
-                    let err_code = e.win32_error().unwrap();
-                    return Err(if err_code == ERROR_ALREADY_EXISTS {
-                        ShmemError::MappingIdExists
-                    } else {
-                        ShmemError::MapCreateFailed(err_code.0)
-                    });
-                }
+        match CreateFileMapping(
+            h_handle,
+            None,
+            PAGE_READWRITE,
+            high_size,
+            low_size,
+            unique_id,
+        ) {
+            Ok(v) => v,
+            Err(e) => {
+                let err_code = e.win32_error().unwrap();
+                return Err(if err_code == ERROR_ALREADY_EXISTS {
+                    ShmemError::MappingIdExists
+                } else {
+                    ShmemError::MapCreateFailed(err_code.0)
+                });
             }
-        }
-        Err(e) if e.kind() == ErrorKind::AlreadyExists => return Err(ShmemError::MappingIdExists),
-        Err(e) => {
-            return Err(ShmemError::MapCreateFailed(e.raw_os_error().unwrap() as _));
         }
     };
     trace!("0x{:X}", map_h);
@@ -296,9 +278,39 @@ fn new_map(unique_id: &str, map_size: usize) -> Result<MapData, ShmemError> {
     })
 }
 
+fn create_persistent_file_mapping(unique_id: &str, map_size: usize) -> Result<MapData, ShmemError> {
+    // Create file to back the shared memory
+    let mut file_path = get_tmp_dir()?;
+    file_path.push(unique_id.trim_start_matches('/'));
+    debug!(
+        "Creating persistent_file at {}",
+        file_path.to_string_lossy()
+    );
+
+    match OpenOptions::new()
+        .read(true)
+        .write(true)
+        .share_mode((FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE).0)
+        .attributes((FILE_ATTRIBUTE_TEMPORARY).0)
+        .create_new(true)
+        .open(&file_path)
+    {
+        Ok(f) => create_file_mapping(unique_id, map_size, Some(f)),
+        Err(e) if e.kind() == ErrorKind::AlreadyExists => Err(ShmemError::MappingIdExists),
+        Err(e) => Err(ShmemError::MapCreateFailed(e.raw_os_error().unwrap() as _)),
+    }
+}
+
 //Creates a mapping specified by the uid and size
-pub fn create_mapping(unique_id: &str, map_size: usize) -> Result<MapData, ShmemError> {
-    new_map(unique_id, map_size)
+pub fn create_mapping(
+    unique_id: &str,
+    map_size: usize,
+    ext: &ShmemConfExt,
+) -> Result<MapData, ShmemError> {
+    match ext.suppress_persistency {
+        true => create_file_mapping(unique_id, map_size, None),
+        false => create_persistent_file_mapping(unique_id, map_size),
+    }
 }
 
 //Opens an existing mapping specified by its uid
@@ -307,5 +319,5 @@ pub fn open_mapping(
     _map_size: usize,
     ext: &ShmemConfExt,
 ) -> Result<MapData, ShmemError> {
-    open_map(unique_id, ext.allow_raw)
+    open_map(unique_id, ext)
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -139,11 +139,11 @@ fn get_tmp_dir() -> Result<PathBuf, ShmemError> {
 }
 
 fn map_error<const CREATE: bool>(error: u32) -> Result<MapData, ShmemError> {
-    if CREATE {
+    Err(if CREATE {
         ShmemError::MapCreateFailed(error)
     } else {
         ShmemError::MapOpenFailed(error)
-    }
+    })
 }
 
 fn attach_file_mapping<const CREATE: bool>(
@@ -268,7 +268,7 @@ fn attach_persistent_file_mapping<const CREATE: bool>(
             if !CREATE && allow_raw {
                 // This may be a mapping that isnt managed by this crate
                 // Try to open the mapping without any backing file
-                attach_file_mapping::<false>(unique_id, map_size, None)
+                return attach_file_mapping::<false>(unique_id, map_size, None);
             }
             map_error::<CREATE>(e.raw_os_error().unwrap() as _)
         }
@@ -283,7 +283,7 @@ pub fn attach<const CREATE: bool>(
 ) -> Result<MapData, ShmemError> {
     match ext.suppress_persistency {
         true => attach_file_mapping::<CREATE>(unique_id, map_size, None),
-        false => attach_persistent_file_mapping::<CREATE>(unique_id, map_size),
+        false => attach_persistent_file_mapping::<CREATE>(unique_id, map_size, ext.allow_raw),
     }
 }
 
@@ -293,7 +293,7 @@ pub fn create_mapping(
     map_size: usize,
     ext: &ShmemConfExt,
 ) -> Result<MapData, ShmemError> {
-    attach::<true>(unique_id, map_size)
+    attach::<true>(unique_id, map_size, ext)
 }
 
 //Opens an existing mapping specified by its uid
@@ -302,5 +302,5 @@ pub fn open_mapping(
     map_size: usize,
     ext: &ShmemConfExt,
 ) -> Result<MapData, ShmemError> {
-    attach::<false>(unique_id, map_size)
+    attach::<false>(unique_id, map_size, ext)
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,6 +1,6 @@
 use std::fs::{File, OpenOptions};
 use std::io::ErrorKind;
-use std::os::windows::fs::{AsRawHandle, OpenOptionsExt};
+use std::os::windows::{fs::OpenOptionsExt, io::AsRawHandle};
 use std::path::PathBuf;
 
 use crate::{log::*, ShmemConf};

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -220,6 +220,7 @@ fn create_file_mapping(
     let map_h = {
         debug!("Creating memory mapping",);
         let h_handle = persistent_file
+            .as_ref()
             .map(|f| HANDLE(f.as_raw_handle() as _))
             .unwrap_or(INVALID_HANDLE_VALUE);
         let high_size: u32 = ((map_size as u64 & 0xFFFF_FFFF_0000_0000_u64) >> 32) as u32;

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -138,47 +138,73 @@ fn get_tmp_dir() -> Result<PathBuf, ShmemError> {
     }
 }
 
-fn open_map(unique_id: &str, ext: &ShmemConfExt) -> Result<MapData, ShmemError> {
-    let persistent_file = match ext.suppress_persistency {
-        false => {
-            let mut file_path = get_tmp_dir()?;
-            file_path.push(unique_id.trim_start_matches('/'));
-            debug!("Opening persistent_file at {}", file_path.to_string_lossy());
+fn map_error<const CREATE: bool>(error: u32) -> Result<MapData, ShmemError> {
+    if CREATE {
+        ShmemError::MapCreateFailed(error)
+    } else {
+        ShmemError::MapOpenFailed(error)
+    }
+}
 
-            match OpenOptions::new()
-                .read(true)
-                .write(true)
-                .share_mode((FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE).0)
-                .attributes((FILE_ATTRIBUTE_TEMPORARY).0)
-                .create(false)
-                .open(&file_path)
-            {
-                Ok(f) => Some(f),
+fn attach_file_mapping<const CREATE: bool>(
+    unique_id: &str,
+    map_size: usize,
+    persistent_file: Option<File>,
+) -> Result<MapData, ShmemError> {
+    let map_h = {
+        debug!(
+            "{} memory mapping",
+            if CREATE { "Creating" } else { "Opening" },
+        );
+
+        // if there is an existing persistency file OR we create a new mapping, then use CreateFileMapping
+        if persistent_file.is_some() || CREATE {
+            let h_handle = persistent_file
+                .as_ref()
+                .map(|f| HANDLE(f.as_raw_handle() as _))
+                .unwrap_or(INVALID_HANDLE_VALUE);
+            let high_size: u32 = ((map_size as u64 & 0xFFFF_FFFF_0000_0000_u64) >> 32) as u32;
+            let low_size: u32 = (map_size as u64 & 0xFFFF_FFFF_u64) as u32;
+            trace!(
+                "CreateFileMapping({:?}, NULL, {:X}, {}, {}, '{}')",
+                h_handle,
+                PAGE_READWRITE.0,
+                high_size,
+                low_size,
+                unique_id,
+            );
+
+            match CreateFileMapping(
+                h_handle,
+                None,
+                PAGE_READWRITE,
+                high_size,
+                low_size,
+                unique_id,
+            ) {
+                Ok(v) => v,
                 Err(e) => {
-                    if !ext.allow_raw {
-                        return Err(ShmemError::MapOpenFailed(e.raw_os_error().unwrap() as _));
-                    }
-                    None
+                    let err_code = e.win32_error().unwrap();
+                    return Err(if err_code == ERROR_ALREADY_EXISTS {
+                        ShmemError::MappingIdExists
+                    } else {
+                        map_error::<CREATE>(err_code.0)
+                    });
                 }
             }
-        }
-        true => None,
-    };
-
-    let map_h = {
-        //Open Mapping
-        debug!("Opening memory mapping",);
-
-        trace!(
-            "OpenFileMappingW({:?}, {}, '{}')",
-            FILE_MAP_ALL_ACCESS,
-            false,
-            unique_id,
-        );
-        match OpenFileMapping(FILE_MAP_ALL_ACCESS, false, unique_id) {
-            Ok(h) => h,
-            Err(e) => {
-                return Err(ShmemError::MapOpenFailed(e.win32_error().unwrap().0));
+        } else {
+            // open existing mapping instead
+            trace!(
+                "OpenFileMappingW({:?}, {}, '{}')",
+                FILE_MAP_ALL_ACCESS,
+                false,
+                unique_id,
+            );
+            match OpenFileMapping(FILE_MAP_ALL_ACCESS, false, unique_id) {
+                Ok(h) => h,
+                Err(e) => {
+                    return Err(ShmemError::MapOpenFailed(e.win32_error().unwrap().0));
+                }
             }
         }
     };
@@ -193,7 +219,7 @@ fn open_map(unique_id: &str, ext: &ShmemConfExt) -> Result<MapData, ShmemError> 
     );
     let map_ptr = match MapViewOfFile(map_h.as_handle(), FILE_MAP_READ | FILE_MAP_WRITE, 0, 0, 0) {
         Ok(v) => v,
-        Err(e) => return Err(ShmemError::MapOpenFailed(e.win32_error().unwrap().0)),
+        Err(e) => return Err(ShmemError::UnknownOsError(e.win32_error().unwrap().0)),
     };
     trace!("\t{:p}", map_ptr);
 
@@ -204,7 +230,7 @@ fn open_map(unique_id: &str, ext: &ShmemConfExt) -> Result<MapData, ShmemError> 
     }
 
     Ok(MapData {
-        owner: false,
+        owner: CREATE,
         file_map: map_h,
         persistent_file,
         unique_id: unique_id.to_string(),
@@ -213,80 +239,17 @@ fn open_map(unique_id: &str, ext: &ShmemConfExt) -> Result<MapData, ShmemError> 
     })
 }
 
-fn create_file_mapping(
+fn attach_persistent_file_mapping<const CREATE: bool>(
     unique_id: &str,
     map_size: usize,
-    persistent_file: Option<File>,
+    allow_raw: bool,
 ) -> Result<MapData, ShmemError> {
-    let map_h = {
-        debug!("Creating memory mapping",);
-        let h_handle = persistent_file
-            .as_ref()
-            .map(|f| HANDLE(f.as_raw_handle() as _))
-            .unwrap_or(INVALID_HANDLE_VALUE);
-        let high_size: u32 = ((map_size as u64 & 0xFFFF_FFFF_0000_0000_u64) >> 32) as u32;
-        let low_size: u32 = (map_size as u64 & 0xFFFF_FFFF_u64) as u32;
-        trace!(
-            "CreateFileMapping({:?}, NULL, {:X}, {}, {}, '{}')",
-            h_handle,
-            PAGE_READWRITE.0,
-            high_size,
-            low_size,
-            unique_id,
-        );
-
-        match CreateFileMapping(
-            h_handle,
-            None,
-            PAGE_READWRITE,
-            high_size,
-            low_size,
-            unique_id,
-        ) {
-            Ok(v) => v,
-            Err(e) => {
-                let err_code = e.win32_error().unwrap();
-                return Err(if err_code == ERROR_ALREADY_EXISTS {
-                    ShmemError::MappingIdExists
-                } else {
-                    ShmemError::MapCreateFailed(err_code.0)
-                });
-            }
-        }
-    };
-    trace!("0x{:X}", map_h);
-
-    //Map mapping into address space
-    debug!("Loading mapping into address space");
-    trace!(
-        "MapViewOfFile(0x{:X}, {:X}, 0, 0, 0)",
-        map_h,
-        (FILE_MAP_READ | FILE_MAP_WRITE).0,
-    );
-    let map_ptr = match MapViewOfFile(map_h.as_handle(), FILE_MAP_READ | FILE_MAP_WRITE, 0, 0, 0) {
-        Ok(v) => v,
-        Err(e) => {
-            return Err(ShmemError::MapCreateFailed(e.win32_error().unwrap().0));
-        }
-    };
-    trace!("\t{:p}", map_ptr);
-
-    Ok(MapData {
-        owner: true,
-        file_map: map_h,
-        persistent_file,
-        unique_id: unique_id.to_string(),
-        map_size,
-        view: map_ptr,
-    })
-}
-
-fn create_persistent_file_mapping(unique_id: &str, map_size: usize) -> Result<MapData, ShmemError> {
     // Create file to back the shared memory
     let mut file_path = get_tmp_dir()?;
     file_path.push(unique_id.trim_start_matches('/'));
     debug!(
-        "Creating persistent_file at {}",
+        "{} persistent_file at {}",
+        if CREATE { "Creating" } else { "Opening" },
         file_path.to_string_lossy()
     );
 
@@ -295,12 +258,32 @@ fn create_persistent_file_mapping(unique_id: &str, map_size: usize) -> Result<Ma
         .write(true)
         .share_mode((FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE).0)
         .attributes((FILE_ATTRIBUTE_TEMPORARY).0)
-        .create_new(true)
+        .create_new(CREATE)
+        .create(false)
         .open(&file_path)
     {
-        Ok(f) => create_file_mapping(unique_id, map_size, Some(f)),
+        Ok(f) => attach_file_mapping::<CREATE>(unique_id, map_size, Some(f)),
         Err(e) if e.kind() == ErrorKind::AlreadyExists => Err(ShmemError::MappingIdExists),
-        Err(e) => Err(ShmemError::MapCreateFailed(e.raw_os_error().unwrap() as _)),
+        Err(e) => {
+            if !CREATE && allow_raw {
+                // This may be a mapping that isnt managed by this crate
+                // Try to open the mapping without any backing file
+                attach_file_mapping::<false>(unique_id, map_size, None)
+            }
+            map_error::<CREATE>(e.raw_os_error().unwrap() as _)
+        }
+    }
+}
+
+//Creates a mapping specified by the uid and size
+pub fn attach<const CREATE: bool>(
+    unique_id: &str,
+    map_size: usize,
+    ext: &ShmemConfExt,
+) -> Result<MapData, ShmemError> {
+    match ext.suppress_persistency {
+        true => attach_file_mapping::<CREATE>(unique_id, map_size, None),
+        false => attach_persistent_file_mapping::<CREATE>(unique_id, map_size),
     }
 }
 
@@ -310,17 +293,14 @@ pub fn create_mapping(
     map_size: usize,
     ext: &ShmemConfExt,
 ) -> Result<MapData, ShmemError> {
-    match ext.suppress_persistency {
-        true => create_file_mapping(unique_id, map_size, None),
-        false => create_persistent_file_mapping(unique_id, map_size),
-    }
+    attach::<true>(unique_id, map_size)
 }
 
 //Opens an existing mapping specified by its uid
 pub fn open_mapping(
     unique_id: &str,
-    _map_size: usize,
+    map_size: usize,
     ext: &ShmemConfExt,
 ) -> Result<MapData, ShmemError> {
-    open_map(unique_id, ext)
+    attach::<false>(unique_id, map_size)
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,6 +1,6 @@
 use std::fs::{File, OpenOptions};
 use std::io::ErrorKind;
-use std::os::windows::fs::{OpenOptionsExt, AsRawHandle};
+use std::os::windows::fs::{AsRawHandle, OpenOptionsExt};
 use std::path::PathBuf;
 
 use crate::{log::*, ShmemConf};

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -139,36 +139,37 @@ fn get_tmp_dir() -> Result<PathBuf, ShmemError> {
 }
 
 fn open_map(unique_id: &str, ext: &ShmemConfExt) -> Result<MapData, ShmemError> {
-    // Create file to back the shared memory
-    let mut file_path = get_tmp_dir()?;
-    file_path.push(unique_id.trim_start_matches('/'));
-    debug!("Opening persistent_file at {}", file_path.to_string_lossy());
-
     let persistent_file = match ext.suppress_persistency {
-        false => match OpenOptions::new()
-            .read(true)
-            .write(true)
-            .share_mode((FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE).0)
-            .attributes((FILE_ATTRIBUTE_TEMPORARY).0)
-            .create(false)
-            .open(&file_path)
-        {
-            Ok(f) => Some(f),
-            Err(e) => {
-                if !ext.allow_raw {
-                    return Err(ShmemError::MapOpenFailed(e.raw_os_error().unwrap() as _));
+        false => {
+            let mut file_path = get_tmp_dir()?;
+            file_path.push(unique_id.trim_start_matches('/'));
+            info!("Opening persistent_file at {}", file_path.to_string_lossy());
+
+            match OpenOptions::new()
+                .read(true)
+                .write(true)
+                .share_mode((FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE).0)
+                .attributes((FILE_ATTRIBUTE_TEMPORARY).0)
+                .create(false)
+                .open(&file_path)
+            {
+                Ok(f) => Some(f),
+                Err(e) => {
+                    if !ext.allow_raw {
+                        return Err(ShmemError::MapOpenFailed(e.raw_os_error().unwrap() as _));
+                    }
+                    None
                 }
-                None
             }
-        },
+        }
         true => None,
     };
 
     let map_h = {
         //Open Mapping
-        debug!("Opening memory mapping",);
+        info!("Opening memory mapping",);
 
-        trace!(
+        info!(
             "OpenFileMappingW({:?}, {}, '{}')",
             FILE_MAP_ALL_ACCESS,
             false,
@@ -218,14 +219,14 @@ fn create_file_mapping(
     persistent_file: Option<File>,
 ) -> Result<MapData, ShmemError> {
     let map_h = {
-        debug!("Creating memory mapping",);
+        info!("Creating memory mapping",);
         let h_handle = persistent_file
             .as_ref()
             .map(|f| HANDLE(f.as_raw_handle() as _))
             .unwrap_or(INVALID_HANDLE_VALUE);
         let high_size: u32 = ((map_size as u64 & 0xFFFF_FFFF_0000_0000_u64) >> 32) as u32;
         let low_size: u32 = (map_size as u64 & 0xFFFF_FFFF_u64) as u32;
-        trace!(
+        info!(
             "CreateFileMapping({:?}, NULL, {:X}, {}, {}, '{}')",
             h_handle,
             PAGE_READWRITE.0,
@@ -284,7 +285,7 @@ fn create_persistent_file_mapping(unique_id: &str, map_size: usize) -> Result<Ma
     // Create file to back the shared memory
     let mut file_path = get_tmp_dir()?;
     file_path.push(unique_id.trim_start_matches('/'));
-    debug!(
+    info!(
         "Creating persistent_file at {}",
         file_path.to_string_lossy()
     );

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -169,7 +169,7 @@ fn new_map(
             let low_size: u32 = (map_size as u64 & 0xFFFF_FFFF_u64) as u32;
             trace!(
                 "CreateFileMapping({:?}, NULL, {:X}, {}, {}, '{}')",
-                HANDLE(f.as_raw_handle() as _),
+                INVALID_HANDLE_VALUE,
                 PAGE_READWRITE.0,
                 high_size,
                 low_size,
@@ -177,7 +177,7 @@ fn new_map(
             );
 
             match CreateFileMapping(
-                HANDLE(f.as_raw_handle() as _),
+                INVALID_HANDLE_VALUE,
                 None,
                 PAGE_READWRITE,
                 high_size,

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -176,7 +176,7 @@ fn open_map(unique_id: &str, allow_raw: bool) -> Result<MapData, ShmemError> {
                 unique_id,
             );
             match OpenFileMapping(FILE_MAP_ALL_ACCESS, false, unique_id) {
-                Ok(h) => h,
+                Ok(h) => (None, h),
                 Err(e) => {
                     return Err(ShmemError::MapOpenFailed(e.win32_error().unwrap().0));
                 }
@@ -298,7 +298,7 @@ fn new_map(unique_id: &str, map_size: usize) -> Result<MapData, ShmemError> {
 
 //Creates a mapping specified by the uid and size
 pub fn create_mapping(unique_id: &str, map_size: usize) -> Result<MapData, ShmemError> {
-    new_map(unique_id, map_size, true)
+    new_map(unique_id, map_size)
 }
 
 //Opens an existing mapping specified by its uid
@@ -307,5 +307,5 @@ pub fn open_mapping(
     map_size: usize,
     ext: &ShmemConfExt,
 ) -> Result<MapData, ShmemError> {
-    open_map(unique_id, false, ext.allow_raw)
+    open_map(unique_id, ext.allow_raw)
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,6 +1,6 @@
 use std::fs::{File, OpenOptions};
 use std::io::ErrorKind;
-use std::os::windows::fs::OpenOptionsExt;
+use std::os::windows::fs::{OpenOptionsExt, AsRawHandle};
 use std::path::PathBuf;
 
 use crate::{log::*, ShmemConf};
@@ -155,7 +155,7 @@ fn open_map(unique_id: &str, ext: &ShmemConfExt) -> Result<MapData, ShmemError> 
         {
             Ok(f) => Some(f),
             Err(e) => {
-                if !allow_raw {
+                if !ext.allow_raw {
                     return Err(ShmemError::MapOpenFailed(e.raw_os_error().unwrap() as _));
                 }
             }
@@ -174,7 +174,7 @@ fn open_map(unique_id: &str, ext: &ShmemConfExt) -> Result<MapData, ShmemError> 
             unique_id,
         );
         match OpenFileMapping(FILE_MAP_ALL_ACCESS, false, unique_id) {
-            Ok(h) => (Some(f), h),
+            Ok(h) => h,
             Err(e) => {
                 return Err(ShmemError::MapOpenFailed(e.win32_error().unwrap().0));
             }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -10,8 +10,8 @@ use crate::ShmemError;
 
 #[derive(Clone, Default)]
 pub struct ShmemConfExt {
-    allow_raw: bool,
-    suppress_persistency: bool,
+    pub allow_raw: bool,
+    pub suppress_persistency: bool,
 }
 
 impl ShmemConf {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -131,14 +131,13 @@ fn get_tmp_dir() -> Result<PathBuf, ShmemError> {
     }
 }
 
-fn open_map(unique_id: &str, mut map_size: usize, allow_raw: bool) -> Result<MapData, ShmemError> {
+fn open_map(unique_id: &str, allow_raw: bool) -> Result<MapData, ShmemError> {
     // Create file to back the shared memory
     let mut file_path = get_tmp_dir()?;
     file_path.push(unique_id.trim_start_matches('/'));
     debug!("Opening persistent_file at {}", file_path.to_string_lossy());
 
-    let mut persistent_file = None;
-    let map_h = match OpenOptions::new()
+    let (persistent_file, map_h) = match OpenOptions::new()
         .read(true)
         .write(true)
         .share_mode((FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE).0)
@@ -157,7 +156,7 @@ fn open_map(unique_id: &str, mut map_size: usize, allow_raw: bool) -> Result<Map
                 unique_id,
             );
             match OpenFileMapping(FILE_MAP_ALL_ACCESS, false, unique_id) {
-                Ok(h) => h,
+                Ok(h) => (Some(f), h),
                 Err(e) => {
                     return Err(ShmemError::MapOpenFailed(e.win32_error().unwrap().0));
                 }
@@ -199,24 +198,23 @@ fn open_map(unique_id: &str, mut map_size: usize, allow_raw: bool) -> Result<Map
     };
     trace!("\t{:p}", map_ptr);
 
-    //Get the real size of the openned mapping
+    //Get the real size of the opened mapping
     let mut info = MEMORY_BASIC_INFORMATION::default();
     if let Err(e) = VirtualQuery(map_ptr.as_mut_ptr(), &mut info) {
         return Err(ShmemError::UnknownOsError(e.win32_error().unwrap().0));
     }
-    map_size = info.RegionSize;
 
     Ok(MapData {
         owner: false,
         file_map: map_h,
         persistent_file,
         unique_id: unique_id.to_string(),
-        map_size,
+        map_size: info.RegionSize,
         view: map_ptr,
     })
 }
 
-fn new_map(unique_id: &str, mut map_size: usize, allow_raw: bool) -> Result<MapData, ShmemError> {
+fn new_map(unique_id: &str, map_size: usize) -> Result<MapData, ShmemError> {
     // Create file to back the shared memory
     let mut file_path = get_tmp_dir()?;
     file_path.push(unique_id.trim_start_matches('/'));
@@ -225,8 +223,7 @@ fn new_map(unique_id: &str, mut map_size: usize, allow_raw: bool) -> Result<MapD
         file_path.to_string_lossy()
     );
 
-    let mut persistent_file = None;
-    let map_h = match OpenOptions::new()
+    let (persistent_file, map_h) = match OpenOptions::new()
         .read(true)
         .write(true)
         .share_mode((FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE).0)
@@ -256,10 +253,7 @@ fn new_map(unique_id: &str, mut map_size: usize, allow_raw: bool) -> Result<MapD
                 low_size,
                 unique_id,
             ) {
-                Ok(v) => {
-                    persistent_file = Some(f);
-                    v
-                }
+                Ok(v) => (Some(f), v),
                 Err(e) => {
                     let err_code = e.win32_error().unwrap();
                     return Err(if err_code == ERROR_ALREADY_EXISTS {
@@ -304,7 +298,7 @@ fn new_map(unique_id: &str, mut map_size: usize, allow_raw: bool) -> Result<MapD
 
 //Creates a mapping specified by the uid and size
 pub fn create_mapping(unique_id: &str, map_size: usize) -> Result<MapData, ShmemError> {
-    new_map(unique_id, map_size, true, false)
+    new_map(unique_id, map_size, true)
 }
 
 //Opens an existing mapping specified by its uid
@@ -313,5 +307,5 @@ pub fn open_mapping(
     map_size: usize,
     ext: &ShmemConfExt,
 ) -> Result<MapData, ShmemError> {
-    open_map(unique_id, map_size, false, ext.allow_raw)
+    open_map(unique_id, false, ext.allow_raw)
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -65,6 +65,7 @@ impl Drop for MapData {
         // deleted once all handles have been closed and no new handles can be opened
         // because the file has been renamed. This matches the behavior of shm_unlink()
         // on unix.
+        /*
         if self.owner {
             let mut base_path = get_tmp_dir().unwrap();
 
@@ -106,6 +107,7 @@ impl Drop for MapData {
                 }
             };
         }
+        */
     }
 }
 
@@ -308,13 +310,12 @@ fn create_persistent_file_mapping(unique_id: &str, map_size: usize) -> Result<Ma
 pub fn create_mapping(
     unique_id: &str,
     map_size: usize,
-    _ext: &ShmemConfExt,
+    ext: &ShmemConfExt,
 ) -> Result<MapData, ShmemError> {
-    create_persistent_file_mapping(unique_id, map_size)
-    //match ext.suppress_persistency {
-    //    true => create_file_mapping(unique_id, map_size, None),
-    //    false => create_persistent_file_mapping(unique_id, map_size),
-    //}
+    match ext.suppress_persistency {
+        true => create_file_mapping(unique_id, map_size, None),
+        false => create_persistent_file_mapping(unique_id, map_size),
+    }
 }
 
 //Opens an existing mapping specified by its uid

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -154,7 +154,7 @@ fn open_map(unique_id: &str, ext: &ShmemConfExt) -> Result<MapData, ShmemError> 
                 .open(&file_path)
             {
                 Ok(f) => Some(f),
-                Err(e) => {
+                Err(_e) => {
                     //if !ext.allow_raw {
                     //    return Err(ShmemError::MapOpenFailed(e.raw_os_error().unwrap() as _));
                     //}

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -158,6 +158,7 @@ fn open_map(unique_id: &str, ext: &ShmemConfExt) -> Result<MapData, ShmemError> 
                 if !ext.allow_raw {
                     return Err(ShmemError::MapOpenFailed(e.raw_os_error().unwrap() as _));
                 }
+                None
             }
         },
         true => None,

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -164,7 +164,7 @@ fn open_map(unique_id: &str, allow_raw: bool) -> Result<MapData, ShmemError> {
         }
         Err(e) => {
             if !allow_raw {
-                return Err(ShmemError::MapOpenFailed(e.win32_error().unwrap().0));
+                return Err(ShmemError::MapOpenFailed(e.raw_os_error().unwrap() as _));
             }
 
             // This may be a mapping that isnt managed by this crate

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,6 +1,6 @@
 use std::fs::{File, OpenOptions};
 use std::io::ErrorKind;
-use std::os::windows::{fs::OpenOptionsExt, io::AsRawHandle};
+use std::os::windows::fs::OpenOptionsExt;
 use std::path::PathBuf;
 
 use crate::{log::*, ShmemConf};
@@ -73,7 +73,7 @@ impl Drop for MapData {
             {
                 Ok(_) => {
                     // 2. Rename file to prevent further use
-                    base_path.push(&format!(
+                    base_path.push(format!(
                         "{}_deleted",
                         self.unique_id.trim_start_matches('/')
                     ));

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -65,7 +65,6 @@ impl Drop for MapData {
         // deleted once all handles have been closed and no new handles can be opened
         // because the file has been renamed. This matches the behavior of shm_unlink()
         // on unix.
-        /*
         if self.owner {
             let mut base_path = get_tmp_dir().unwrap();
 
@@ -107,7 +106,6 @@ impl Drop for MapData {
                 }
             };
         }
-        */
     }
 }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -271,8 +271,6 @@ fn create_file_mapping(
     };
     trace!("\t{:p}", map_ptr);
 
-    *map_ptr = 0;
-
     Ok(MapData {
         owner: true,
         file_map: map_h,

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -143,13 +143,13 @@ fn open_map(unique_id: &str, ext: &ShmemConfExt) -> Result<MapData, ShmemError> 
         false => {
             let mut file_path = get_tmp_dir()?;
             file_path.push(unique_id.trim_start_matches('/'));
-            debug!("Opening persistent_file at {}", file_path.to_string_lossy());
+            println!("Opening persistent_file at {}", file_path.to_string_lossy());
 
             match OpenOptions::new()
                 .read(true)
                 .write(true)
                 .share_mode((FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE).0)
-                //.attributes((FILE_ATTRIBUTE_TEMPORARY).0)
+                .attributes((FILE_ATTRIBUTE_TEMPORARY).0)
                 .create(false)
                 .open(&file_path)
             {
@@ -285,7 +285,7 @@ fn create_persistent_file_mapping(unique_id: &str, map_size: usize) -> Result<Ma
     // Create file to back the shared memory
     let mut file_path = get_tmp_dir()?;
     file_path.push(unique_id.trim_start_matches('/'));
-    debug!(
+    println!(
         "Creating persistent_file at {}",
         file_path.to_string_lossy()
     );
@@ -294,7 +294,7 @@ fn create_persistent_file_mapping(unique_id: &str, map_size: usize) -> Result<Ma
         .read(true)
         .write(true)
         .share_mode((FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE).0)
-        //.attributes((FILE_ATTRIBUTE_TEMPORARY).0)
+        .attributes((FILE_ATTRIBUTE_TEMPORARY).0)
         .create_new(true)
         .open(&file_path)
     {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -154,10 +154,10 @@ fn open_map(unique_id: &str, ext: &ShmemConfExt) -> Result<MapData, ShmemError> 
                 .open(&file_path)
             {
                 Ok(f) => Some(f),
-                Err(_e) => {
-                    //if !ext.allow_raw {
-                    //    return Err(ShmemError::MapOpenFailed(e.raw_os_error().unwrap() as _));
-                    //}
+                Err(e) => {
+                    if !ext.allow_raw {
+                        return Err(ShmemError::MapOpenFailed(e.raw_os_error().unwrap() as _));
+                    }
                     None
                 }
             }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -143,7 +143,7 @@ fn open_map(unique_id: &str, ext: &ShmemConfExt) -> Result<MapData, ShmemError> 
         false => {
             let mut file_path = get_tmp_dir()?;
             file_path.push(unique_id.trim_start_matches('/'));
-            println!("Opening persistent_file at {}", file_path.to_string_lossy());
+            debug!("Opening persistent_file at {}", file_path.to_string_lossy());
 
             match OpenOptions::new()
                 .read(true)
@@ -271,6 +271,8 @@ fn create_file_mapping(
     };
     trace!("\t{:p}", map_ptr);
 
+    *map_ptr = 0;
+
     Ok(MapData {
         owner: true,
         file_map: map_h,
@@ -285,7 +287,7 @@ fn create_persistent_file_mapping(unique_id: &str, map_size: usize) -> Result<Ma
     // Create file to back the shared memory
     let mut file_path = get_tmp_dir()?;
     file_path.push(unique_id.trim_start_matches('/'));
-    println!(
+    debug!(
         "Creating persistent_file at {}",
         file_path.to_string_lossy()
     );

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -171,9 +171,7 @@ fn open_map(unique_id: &str, ext: &ShmemConfExt) -> Result<MapData, ShmemError> 
 
         info!(
             "OpenFileMappingW({:?}, {}, '{}')",
-            FILE_MAP_ALL_ACCESS,
-            false,
-            unique_id,
+            FILE_MAP_ALL_ACCESS, false, unique_id,
         );
         match OpenFileMapping(FILE_MAP_ALL_ACCESS, false, unique_id) {
             Ok(h) => h,
@@ -228,11 +226,7 @@ fn create_file_mapping(
         let low_size: u32 = (map_size as u64 & 0xFFFF_FFFF_u64) as u32;
         info!(
             "CreateFileMapping({:?}, NULL, {:X}, {}, {}, '{}')",
-            h_handle,
-            PAGE_READWRITE.0,
-            high_size,
-            low_size,
-            unique_id,
+            h_handle, PAGE_READWRITE.0, high_size, low_size, unique_id,
         );
 
         match CreateFileMapping(

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -131,82 +131,40 @@ fn get_tmp_dir() -> Result<PathBuf, ShmemError> {
     }
 }
 
-fn new_map(
-    unique_id: &str,
-    mut map_size: usize,
-    create: bool,
-    allow_raw: bool,
-) -> Result<MapData, ShmemError> {
+fn open_map(unique_id: &str, mut map_size: usize, allow_raw: bool) -> Result<MapData, ShmemError> {
     // Create file to back the shared memory
     let mut file_path = get_tmp_dir()?;
     file_path.push(unique_id.trim_start_matches('/'));
-    debug!(
-        "{} persistent_file at {}",
-        if create { "Creating" } else { "Openning" },
-        file_path.to_string_lossy()
-    );
-
-    let mut opt = OpenOptions::new();
-    opt.read(true)
-        .write(true)
-        .share_mode((FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE).0)
-        .attributes((FILE_ATTRIBUTE_TEMPORARY).0);
-    if create {
-        opt.create_new(true);
-    } else {
-        opt.create(false);
-    };
+    debug!("Opening persistent_file at {}", file_path.to_string_lossy());
 
     let mut persistent_file = None;
-    let map_h = match opt.open(&file_path) {
+    let map_h = match OpenOptions::new()
+        .read(true)
+        .write(true)
+        .share_mode((FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE).0)
+        .attributes((FILE_ATTRIBUTE_TEMPORARY).0)
+        .create(false)
+        .open(&file_path)
+    {
         Ok(f) => {
-            //Create/open Mapping using persistent file
-            debug!(
-                "{} memory mapping",
-                if create { "Creating" } else { "Openning" },
-            );
-            let high_size: u32 = ((map_size as u64 & 0xFFFF_FFFF_0000_0000_u64) >> 32) as u32;
-            let low_size: u32 = (map_size as u64 & 0xFFFF_FFFF_u64) as u32;
-            trace!(
-                "CreateFileMapping({:?}, NULL, {:X}, {}, {}, '{}')",
-                INVALID_HANDLE_VALUE,
-                PAGE_READWRITE.0,
-                high_size,
-                low_size,
-                unique_id,
-            );
+            //Open Mapping using persistent file
+            debug!("Openning memory mapping",);
 
-            match CreateFileMapping(
-                INVALID_HANDLE_VALUE,
-                None,
-                PAGE_READWRITE,
-                high_size,
-                low_size,
+            trace!(
+                "OpenFileMappingW({:?}, {}, '{}')",
+                FILE_MAP_ALL_ACCESS,
+                false,
                 unique_id,
-            ) {
-                Ok(v) => {
-                    persistent_file = Some(f);
-                    v
-                }
+            );
+            match OpenFileMapping(FILE_MAP_ALL_ACCESS, false, unique_id) {
+                Ok(h) => h,
                 Err(e) => {
-                    let err_code = e.win32_error().unwrap();
-                    return if err_code == ERROR_ALREADY_EXISTS {
-                        Err(ShmemError::MappingIdExists)
-                    } else {
-                        Err(if create {
-                            ShmemError::MapCreateFailed(err_code.0)
-                        } else {
-                            ShmemError::MapOpenFailed(err_code.0)
-                        })
-                    };
+                    return Err(ShmemError::MapOpenFailed(e.win32_error().unwrap().0));
                 }
             }
         }
-        Err(e) if e.kind() == ErrorKind::AlreadyExists => return Err(ShmemError::MappingIdExists),
         Err(e) => {
-            if create {
-                return Err(ShmemError::MapCreateFailed(e.raw_os_error().unwrap() as _));
-            } else if !allow_raw {
+            if !allow_raw {
                 return Err(ShmemError::MapOpenFailed(ERROR_FILE_NOT_FOUND.0));
             }
 
@@ -237,27 +195,105 @@ fn new_map(
     );
     let map_ptr = match MapViewOfFile(map_h.as_handle(), FILE_MAP_READ | FILE_MAP_WRITE, 0, 0, 0) {
         Ok(v) => v,
+        Err(e) => return Err(ShmemError::MapOpenFailed(e.win32_error().unwrap().0)),
+    };
+    trace!("\t{:p}", map_ptr);
+
+    //Get the real size of the openned mapping
+    let mut info = MEMORY_BASIC_INFORMATION::default();
+    if let Err(e) = VirtualQuery(map_ptr.as_mut_ptr(), &mut info) {
+        return Err(ShmemError::UnknownOsError(e.win32_error().unwrap().0));
+    }
+    map_size = info.RegionSize;
+
+    Ok(MapData {
+        owner: false,
+        file_map: map_h,
+        persistent_file,
+        unique_id: unique_id.to_string(),
+        map_size,
+        view: map_ptr,
+    })
+}
+
+fn new_map(unique_id: &str, mut map_size: usize, allow_raw: bool) -> Result<MapData, ShmemError> {
+    // Create file to back the shared memory
+    let mut file_path = get_tmp_dir()?;
+    file_path.push(unique_id.trim_start_matches('/'));
+    debug!(
+        "Creating persistent_file at {}",
+        file_path.to_string_lossy()
+    );
+
+    let mut persistent_file = None;
+    let map_h = match OpenOptions::new()
+        .read(true)
+        .write(true)
+        .share_mode((FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE).0)
+        .attributes((FILE_ATTRIBUTE_TEMPORARY).0)
+        .create_new(true)
+        .open(&file_path)
+    {
+        Ok(f) => {
+            //Create Mapping using persistent file
+            debug!("Creating memory mapping",);
+            let high_size: u32 = ((map_size as u64 & 0xFFFF_FFFF_0000_0000_u64) >> 32) as u32;
+            let low_size: u32 = (map_size as u64 & 0xFFFF_FFFF_u64) as u32;
+            trace!(
+                "CreateFileMapping({:?}, NULL, {:X}, {}, {}, '{}')",
+                INVALID_HANDLE_VALUE,
+                PAGE_READWRITE.0,
+                high_size,
+                low_size,
+                unique_id,
+            );
+
+            match CreateFileMapping(
+                INVALID_HANDLE_VALUE,
+                None,
+                PAGE_READWRITE,
+                high_size,
+                low_size,
+                unique_id,
+            ) {
+                Ok(v) => {
+                    persistent_file = Some(f);
+                    v
+                }
+                Err(e) => {
+                    let err_code = e.win32_error().unwrap();
+                    return Err(if err_code == ERROR_ALREADY_EXISTS {
+                        ShmemError::MappingIdExists
+                    } else {
+                        ShmemError::MapCreateFailed(err_code.0)
+                    });
+                }
+            }
+        }
+        Err(e) if e.kind() == ErrorKind::AlreadyExists => return Err(ShmemError::MappingIdExists),
         Err(e) => {
-            return Err(if create {
-                ShmemError::MapCreateFailed(e.win32_error().unwrap().0)
-            } else {
-                ShmemError::MapOpenFailed(e.win32_error().unwrap().0)
-            })
+            return Err(ShmemError::MapCreateFailed(e.raw_os_error().unwrap() as _));
+        }
+    };
+    trace!("0x{:X}", map_h);
+
+    //Map mapping into address space
+    debug!("Loading mapping into address space");
+    trace!(
+        "MapViewOfFile(0x{:X}, {:X}, 0, 0, 0)",
+        map_h,
+        (FILE_MAP_READ | FILE_MAP_WRITE).0,
+    );
+    let map_ptr = match MapViewOfFile(map_h.as_handle(), FILE_MAP_READ | FILE_MAP_WRITE, 0, 0, 0) {
+        Ok(v) => v,
+        Err(e) => {
+            return Err(ShmemError::MapCreateFailed(e.win32_error().unwrap().0));
         }
     };
     trace!("\t{:p}", map_ptr);
 
-    if !create {
-        //Get the real size of the openned mapping
-        let mut info = MEMORY_BASIC_INFORMATION::default();
-        if let Err(e) = VirtualQuery(map_ptr.as_mut_ptr(), &mut info) {
-            return Err(ShmemError::UnknownOsError(e.win32_error().unwrap().0));
-        }
-        map_size = info.RegionSize;
-    }
-
     Ok(MapData {
-        owner: create,
+        owner: true,
         file_map: map_h,
         persistent_file,
         unique_id: unique_id.to_string(),
@@ -277,5 +313,5 @@ pub fn open_mapping(
     map_size: usize,
     ext: &ShmemConfExt,
 ) -> Result<MapData, ShmemError> {
-    new_map(unique_id, map_size, false, ext.allow_raw)
+    open_map(unique_id, map_size, false, ext.allow_raw)
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -143,7 +143,7 @@ fn open_map(unique_id: &str, ext: &ShmemConfExt) -> Result<MapData, ShmemError> 
         false => {
             let mut file_path = get_tmp_dir()?;
             file_path.push(unique_id.trim_start_matches('/'));
-            info!("Opening persistent_file at {}", file_path.to_string_lossy());
+            debug!("Opening persistent_file at {}", file_path.to_string_lossy());
 
             match OpenOptions::new()
                 .read(true)
@@ -167,11 +167,13 @@ fn open_map(unique_id: &str, ext: &ShmemConfExt) -> Result<MapData, ShmemError> 
 
     let map_h = {
         //Open Mapping
-        info!("Opening memory mapping",);
+        debug!("Opening memory mapping",);
 
-        info!(
+        trace!(
             "OpenFileMappingW({:?}, {}, '{}')",
-            FILE_MAP_ALL_ACCESS, false, unique_id,
+            FILE_MAP_ALL_ACCESS,
+            false,
+            unique_id,
         );
         match OpenFileMapping(FILE_MAP_ALL_ACCESS, false, unique_id) {
             Ok(h) => h,
@@ -217,16 +219,20 @@ fn create_file_mapping(
     persistent_file: Option<File>,
 ) -> Result<MapData, ShmemError> {
     let map_h = {
-        info!("Creating memory mapping",);
+        debug!("Creating memory mapping",);
         let h_handle = persistent_file
             .as_ref()
             .map(|f| HANDLE(f.as_raw_handle() as _))
             .unwrap_or(INVALID_HANDLE_VALUE);
         let high_size: u32 = ((map_size as u64 & 0xFFFF_FFFF_0000_0000_u64) >> 32) as u32;
         let low_size: u32 = (map_size as u64 & 0xFFFF_FFFF_u64) as u32;
-        info!(
+        trace!(
             "CreateFileMapping({:?}, NULL, {:X}, {}, {}, '{}')",
-            h_handle, PAGE_READWRITE.0, high_size, low_size, unique_id,
+            h_handle,
+            PAGE_READWRITE.0,
+            high_size,
+            low_size,
+            unique_id,
         );
 
         match CreateFileMapping(
@@ -279,7 +285,7 @@ fn create_persistent_file_mapping(unique_id: &str, map_size: usize) -> Result<Ma
     // Create file to back the shared memory
     let mut file_path = get_tmp_dir()?;
     file_path.push(unique_id.trim_start_matches('/'));
-    info!(
+    debug!(
         "Creating persistent_file at {}",
         file_path.to_string_lossy()
     );

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -220,7 +220,7 @@ fn create_file_mapping(
     let map_h = {
         debug!("Creating memory mapping",);
         let h_handle = persistent_file
-            .map(|f| f.as_raw_handle() as _)
+            .map(|f| HANDLE(f.as_raw_handle() as _))
             .unwrap_or(INVALID_HANDLE_VALUE);
         let high_size: u32 = ((map_size as u64 & 0xFFFF_FFFF_0000_0000_u64) >> 32) as u32;
         let low_size: u32 = (map_size as u64 & 0xFFFF_FFFF_u64) as u32;

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -308,12 +308,13 @@ fn create_persistent_file_mapping(unique_id: &str, map_size: usize) -> Result<Ma
 pub fn create_mapping(
     unique_id: &str,
     map_size: usize,
-    ext: &ShmemConfExt,
+    _ext: &ShmemConfExt,
 ) -> Result<MapData, ShmemError> {
-    match ext.suppress_persistency {
-        true => create_file_mapping(unique_id, map_size, None),
-        false => create_persistent_file_mapping(unique_id, map_size),
-    }
+    create_persistent_file_mapping(unique_id, map_size)
+    //match ext.suppress_persistency {
+    //    true => create_file_mapping(unique_id, map_size, None),
+    //    false => create_persistent_file_mapping(unique_id, map_size),
+    //}
 }
 
 //Opens an existing mapping specified by its uid

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -149,7 +149,7 @@ fn open_map(unique_id: &str, ext: &ShmemConfExt) -> Result<MapData, ShmemError> 
                 .read(true)
                 .write(true)
                 .share_mode((FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE).0)
-                .attributes((FILE_ATTRIBUTE_TEMPORARY).0)
+                //.attributes((FILE_ATTRIBUTE_TEMPORARY).0)
                 .create(false)
                 .open(&file_path)
             {
@@ -294,7 +294,7 @@ fn create_persistent_file_mapping(unique_id: &str, map_size: usize) -> Result<Ma
         .read(true)
         .write(true)
         .share_mode((FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE).0)
-        .attributes((FILE_ATTRIBUTE_TEMPORARY).0)
+        //.attributes((FILE_ATTRIBUTE_TEMPORARY).0)
         .create_new(true)
         .open(&file_path)
     {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -185,11 +185,11 @@ fn attach_file_mapping<const CREATE: bool>(
                 Ok(v) => v,
                 Err(e) => {
                     let err_code = e.win32_error().unwrap();
-                    return Err(if err_code == ERROR_ALREADY_EXISTS {
-                        ShmemError::MappingIdExists
+                    return if err_code == ERROR_ALREADY_EXISTS {
+                        Err(ShmemError::MappingIdExists)
                     } else {
                         map_error::<CREATE>(err_code.0)
-                    });
+                    };
                 }
             }
         } else {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -155,9 +155,9 @@ fn open_map(unique_id: &str, ext: &ShmemConfExt) -> Result<MapData, ShmemError> 
             {
                 Ok(f) => Some(f),
                 Err(e) => {
-                    if !ext.allow_raw {
-                        return Err(ShmemError::MapOpenFailed(e.raw_os_error().unwrap() as _));
-                    }
+                    //if !ext.allow_raw {
+                    //    return Err(ShmemError::MapOpenFailed(e.raw_os_error().unwrap() as _));
+                    //}
                     None
                 }
             }

--- a/tests/general.rs
+++ b/tests/general.rs
@@ -57,7 +57,7 @@ fn open_os_id() {
     // Drop the owner of the mapping
     drop(s1);
 
-    // Make sure it can be openned again
+    // Make sure it can't be openned again
     assert!(ShmemConf::new().os_id(&os_id).open().is_err());
 
     drop(s2);

--- a/tests/posix_semantics.rs
+++ b/tests/posix_semantics.rs
@@ -7,7 +7,6 @@ fn persistence() {
     let os_id = {
         let mut shmem = ShmemConf::new().size(4096).create().unwrap();
         shmem.set_owner(false);
-        unsafe { shmem.as_slice_mut().fill(0) };
         String::from(shmem.get_os_id())
     };
     let mut shmem = ShmemConf::new().os_id(os_id).open().unwrap();

--- a/tests/posix_semantics.rs
+++ b/tests/posix_semantics.rs
@@ -1,34 +1,16 @@
-use shared_memory::{ShmemConf, ShmemConfExt};
+use shared_memory::ShmemConf;
 use std::sync::mpsc::channel;
 use std::thread;
 
 #[test]
 fn persistence() {
     let os_id = {
-        let mut shmem = ShmemConf::new()
-            .size(4096)
-            .ext(ShmemConfExt {
-                #[cfg(target_os = "windows")]
-                allow_raw: true,
-                #[cfg(target_os = "windows")]
-                suppress_persistency: false,
-            })
-            .create()
-            .unwrap();
+        let mut shmem = ShmemConf::new().size(4096).create().unwrap();
         shmem.set_owner(false);
         String::from(shmem.get_os_id())
     };
 
-    let mut shmem = ShmemConf::new()
-        .os_id(os_id)
-        .ext(ShmemConfExt {
-            #[cfg(target_os = "windows")]
-            allow_raw: true,
-            #[cfg(target_os = "windows")]
-            suppress_persistency: false,
-        })
-        .open()
-        .unwrap();
+    let mut shmem = ShmemConf::new().os_id(os_id).open().unwrap();
     shmem.set_owner(true);
 }
 

--- a/tests/posix_semantics.rs
+++ b/tests/posix_semantics.rs
@@ -5,7 +5,16 @@ use std::thread;
 #[test]
 fn persistence() {
     let os_id = {
-        let mut shmem = ShmemConf::new().size(4096).create().unwrap();
+        let mut shmem = ShmemConf::new()
+            .size(4096)
+            .ext(ShmemConfExt {
+                #[cfg(target_os = "windows")]
+                allow_raw: true,
+                #[cfg(target_os = "windows")]
+                suppress_persistency: false,
+            })
+            .create()
+            .unwrap();
         shmem.set_owner(false);
         String::from(shmem.get_os_id())
     };

--- a/tests/posix_semantics.rs
+++ b/tests/posix_semantics.rs
@@ -1,4 +1,4 @@
-use shared_memory::ShmemConf;
+use shared_memory::{ShmemConf, ShmemConfExt};
 use std::sync::mpsc::channel;
 use std::thread;
 
@@ -9,7 +9,17 @@ fn persistence() {
         shmem.set_owner(false);
         String::from(shmem.get_os_id())
     };
-    let mut shmem = ShmemConf::new().os_id(os_id).open().unwrap();
+
+    let mut shmem = ShmemConf::new()
+        .os_id(os_id)
+        .ext(ShmemConfExt {
+            #[cfg(target_os = "windows")]
+            allow_raw: true,
+            #[cfg(target_os = "windows")]
+            suppress_persistency: false,
+        })
+        .open()
+        .unwrap();
     shmem.set_owner(true);
 }
 

--- a/tests/posix_semantics.rs
+++ b/tests/posix_semantics.rs
@@ -7,6 +7,7 @@ fn persistence() {
     let os_id = {
         let mut shmem = ShmemConf::new().size(4096).create().unwrap();
         shmem.set_owner(false);
+        unsafe { shmem.as_slice_mut().fill(0) };
         String::from(shmem.get_os_id())
     };
     let mut shmem = ShmemConf::new().os_id(os_id).open().unwrap();

--- a/tests/windows.rs
+++ b/tests/windows.rs
@@ -1,0 +1,21 @@
+#[cfg(target_os="windows")]
+mod windows_tests {
+    use shared_memory::{ShmemConf, ShmemConfExt};
+
+    #[test]
+    fn suppress_persistency() {
+        let os_id = {
+            let mut shmem = ShmemConf::new()
+                .size(4096)
+                .ext(ShmemConfExt {
+                    allow_raw: false,
+                    suppress_persistency: true,
+                })
+                .create()
+                .unwrap();
+            shmem.set_owner(false);
+            String::from(shmem.get_os_id())
+        };
+        assert!(ShmemConf::new().os_id(os_id).open().is_err());
+    }
+}

--- a/tests/windows.rs
+++ b/tests/windows.rs
@@ -1,4 +1,4 @@
-#[cfg(target_os="windows")]
+#[cfg(target_os = "windows")]
 mod windows_tests {
     use shared_memory::{ShmemConf, ShmemConfExt};
 


### PR DESCRIPTION
On windows platform persistency is implemented through temporary file. This approach is much more intrusive compared to POSIX persistency approach:
- produces extra writes on disk
- consumes disk memory
- persists across reboots

This PR exposes platform-specific setting `ShmemConfExt` and adds `suppress_persistency` option for windows.
Windows code is a little bit refactored to be more readable and support persistency file disabling.
Tests also included.
I also fixed some new clippy errors here and there 

This change is needed for [zenoh](https://github.com/eclipse-zenoh/zenoh) project